### PR TITLE
Atlas mapping.exe

### DIFF
--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -16,29 +16,17 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "ac" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/machinery/air_sensor/atmos{
+	id_tag = "sdmix_sensor";
+	name = "reactor mix sensor"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/blue,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos)
 "ad" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	name = "N20 to remix"
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
-	},
+/obj/machinery/meter/atmos/atmos_waste_loop,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "af" = (
@@ -124,11 +112,12 @@
 /area/chapel/main)
 "aq" = (
 /obj/machinery/door/airlock/ship/maintenance,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "au" = (
@@ -234,15 +223,8 @@
 /turf/open/floor/carpet/ship,
 /area/nsv/weapons)
 "aI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/port)
 "aL" = (
 /obj/machinery/conveyor/slow{
@@ -263,32 +245,36 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "aP" = (
-/obj/effect/turf_decal/ship/techfloor{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/half/green{
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/maintenance/nsv/deck2/port)
 "aT" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 6;
-	icon_state = "pipe11-1"
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/trinary/mixer/layer3{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor{
+	dir = 8;
+	piping_layer = 1
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aV" = (
-/turf/template_noop,
-/area/maintenance/nsv/deck2/starboard)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "aW" = (
 /obj/structure/closet/secure_closet/genpop,
 /obj/structure/window/reinforced{
@@ -315,6 +301,9 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
+"aZ" = (
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "ba" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -335,24 +324,36 @@
 	name = "Abandoned Bar"
 	})
 "bc" = (
-/obj/structure/lattice/catwalk/over/ship,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
+/obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "bf" = (
 /turf/closed/wall/r_wall,
 /area/space)
+"bg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/ship/command{
+	name = "Chief Engineer";
+	req_access_txt = "56";
+	req_one_access_txt = "56"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/heads/chief)
 "bh" = (
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
@@ -391,8 +392,12 @@
 /turf/open/floor/monotile/steel,
 /area/science)
 "bq" = (
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 4;
+	pixel_x = -32
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -437,12 +442,26 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bx" = (
-/obj/effect/turf_decal/tile/ship/blue,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/structure/closet/crate/engineering,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/effect/spawner/lootdrop/maintenance/six,
+/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"by" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "bz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -484,8 +503,12 @@
 /area/hallway/nsv/deck2/primary)
 "bC" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 6
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "bD" = (
@@ -559,8 +582,10 @@
 /turf/open/floor/engine,
 /area/nsv/weapons)
 "bO" = (
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "bW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -579,26 +604,39 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "bY" = (
-/obj/machinery/atmospherics/miner/toxins,
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/obj/machinery/light/small,
-/turf/open/floor/engine/plasma,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
 /area/engine/atmos)
-"ca" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
 "cb" = (
 /obj/structure/lattice,
 /obj/structure/grille/wall,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cf" = (
-/obj/machinery/air_sensor/atmos{
-	id_tag = "sdmix_sensor";
-	name = "reactor mix sensor"
+"cd" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/obj/item/extinguisher/mini,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
+"cf" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 6;
+	icon_state = "pipe11-1"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/trinary/mixer/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/engine/atmos)
 "cj" = (
 /obj/effect/turf_decal/ship/techfloor{
@@ -614,6 +652,16 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/janitor)
+"ck" = (
+/obj/effect/turf_decal/tile/ship/yellow,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "cl" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/template_noop,
@@ -642,15 +690,9 @@
 /turf/open/floor/engine,
 /area/quartermaster/storage)
 "cs" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
+	dir = 8
 	},
-/obj/machinery/camera/autoname,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
-	},
-/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ct" = (
@@ -754,7 +796,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/machinery/vending/engivend,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "cF" = (
@@ -842,7 +884,8 @@
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/carpet/orange,
+/obj/effect/turf_decal/tile/ship/half/yellow,
+/turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "dd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -854,6 +897,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/nsv/deck2/primary)
+"de" = (
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "dg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -911,30 +960,8 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
-"dp" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 8;
-	icon_state = "borderhalf"
-	},
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
 "dq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -942,8 +969,20 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/engine/atmos)
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
+"dr" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "ds" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -967,11 +1006,13 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "dx" = (
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/structure/rack,
-/obj/item/wirecutters,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/item/geiger_counter,
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "dy" = (
 /obj/machinery/light/small,
 /obj/structure/cable/yellow{
@@ -988,6 +1029,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science)
+"dB" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "dC" = (
 /turf/closed/wall/r_wall,
 /area/nsv/weapons/gauss/battery/deck2/port)
@@ -1003,6 +1050,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -1043,17 +1093,6 @@
 /obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
-"dK" = (
-/obj/machinery/computer/deckgun,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/orange,
-/turf/open/floor/plating,
-/area/nsv/weapons)
 "dM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1091,9 +1130,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/yellow{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
@@ -1124,12 +1160,14 @@
 /turf/open/floor/plating,
 /area/science)
 "dW" = (
+/obj/machinery/light/small,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
 /obj/machinery/power/deck_relay,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
@@ -1155,7 +1193,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "ec" = (
 /obj/structure/table,
@@ -1252,15 +1290,18 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science)
 "ev" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+	dir = 8;
+	icon_state = "filter_on"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4;
 	icon_state = "pipe11-1"
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ew" = (
@@ -1274,12 +1315,12 @@
 	},
 /area/nsv/hanger/notkmcstupidhanger)
 "ey" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "ez" = (
@@ -1315,30 +1356,44 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/stack/cable_coil/red,
 /obj/item/rcl/pre_loaded,
-/turf/open/floor/carpet/orange,
+/obj/effect/turf_decal/tile/ship/half/yellow,
+/turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "eD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/ship/yellow{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1;
+	icon_state = "bordercorner"
+	},
 /turf/open/floor/plating{
-	icon_state = "panelscorched"
+	icon_state = "platingdmg2"
 	},
 /area/maintenance/department/engine/atmos)
 "eF" = (
-/obj/item/beacon,
-/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer3{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 9
 	},
+/obj/machinery/meter/atmos,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"eG" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "eH" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
+"eI" = (
+/obj/item/stack/medical/bruise_pack,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "eJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -1413,11 +1468,8 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "eX" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/trinary/mixer/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -1471,26 +1523,34 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "fe" = (
-/obj/machinery/mass_driver{
-	id = "dispo"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/disposalpipe/trunk,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "ff" = (
 /obj/structure/munitions_trolley,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"fi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -1499,6 +1559,15 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
+/area/nsv/weapons)
+"fm" = (
+/obj/item/ship_weapon/ammunition/torpedo/nuke/antonio{
+	name = "Giorno"
+	},
+/obj/structure/bed/dogbed{
+	name = "Antonio's Bed"
+	},
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "fo" = (
 /obj/machinery/door/airlock/highsecurity/ship{
@@ -1520,9 +1589,11 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "fp" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
+/obj/structure/table/reinforced,
+/obj/item/multitool,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "fq" = (
@@ -1548,6 +1619,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
+"fs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "ft" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1569,12 +1649,14 @@
 /turf/open/floor/circuit/telecomms,
 /area/science)
 "fx" = (
+/obj/machinery/computer/deckgun,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/ship/orange,
 /turf/open/floor/plating,
 /area/nsv/weapons)
 "fy" = (
@@ -1621,6 +1703,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"fA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "fB" = (
 /obj/structure/chair{
 	dir = 4
@@ -1698,18 +1786,30 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"fO" = (
+/obj/structure/rack,
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "fP" = (
 /obj/effect/turf_decal/pool,
 /obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "fS" = (
-/obj/structure/sign/directions/supply{
-	pixel_y = -6
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
 	},
-/obj/structure/sign/directions/science,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
+"fT" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "fU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -1766,6 +1866,9 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
 /obj/item/storage/box/monkeycubes,
+/obj/item/reagent_containers/food/snacks/monkeycube/gorilla{
+	name = "BIG FUKING MONKE cube"
+	},
 /obj/item/storage/box/monkeycubes,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/monotile/steel,
@@ -1796,13 +1899,12 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "gd" = (
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/ship/blue{
 	dir = 1;
 	icon_state = "bordercorner"
 	},
+/obj/structure/table,
+/obj/item/weldingtool/mini,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "ge" = (
@@ -1816,11 +1918,13 @@
 /obj/item/paper,
 /obj/item/pen,
 /obj/item/flashlight/atc_wavy_sticks,
+/obj/item/key/fighter_tug,
 /turf/open/floor/carpet/ship,
 /area/nsv/hanger/notkmcstupidhanger)
 "gf" = (
 /obj/structure/tank_dispenser,
-/turf/open/floor/carpet/orange,
+/obj/effect/turf_decal/tile/ship/half/yellow,
+/turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "gg" = (
 /obj/machinery/airalarm/directional/north,
@@ -1831,10 +1935,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/nsv/deck2/starboard)
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "gi" = (
 /obj/machinery/vending/security,
 /turf/open/floor/monotile/steel,
@@ -1852,28 +1958,25 @@
 	},
 /area/maintenance/nsv/deck2/starboard)
 "gm" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/item/weldingtool/mini,
-/obj/effect/turf_decal/tile/ship/yellow{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/blue{
-	dir = 1;
-	icon_state = "bordercorner"
-	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/nsv/deck2/port)
 "gn" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer1{
-	name = "Oxygen to Air Mix";
-	target_pressure = 2000
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	name = "Oxygen to mixtape"
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 4;
+	icon_state = "pipe11-1"
 	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "go" = (
@@ -1905,15 +2008,11 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "gu" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank{
-	id_tag = "o2_sensor_alt"
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide{
+	valve_open = 1
 	},
-/obj/machinery/atmospherics/miner/nitrogen,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
+/turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "gv" = (
 /obj/structure/closet/l3closet/janitor,
@@ -1943,28 +2042,17 @@
 	name = "Abandoned Bar"
 	})
 "gA" = (
-/obj/machinery/door/airlock/ship/command{
-	name = "Master At Arms";
-	req_one_access_txt = "70"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/nsv/weapons)
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
+	name = "EVA";
+	req_one_access_txt = "18"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "gB" = (
 /obj/machinery/power/deck_relay,
 /obj/structure/cable,
@@ -2016,6 +2104,15 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
+"gM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "gO" = (
 /obj/structure/sign/ship/securearea,
 /turf/closed/wall/r_wall,
@@ -2087,23 +2184,15 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery/deck2/port)
 "hc" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "atlas_powder"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "atlas_naval"
-	},
-/obj/item/powder_bag{
-	pixel_y = -10
-	},
-/obj/item/powder_bag,
-/obj/item/powder_bag{
-	pixel_y = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/relic,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "he" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -2123,7 +2212,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/nsv/deck2/starboard)
+/area/engine/break_room)
 "hi" = (
 /obj/structure/closet/secure_closet/munitions_technician,
 /turf/open/floor/carpet/red,
@@ -2172,19 +2261,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
-"ho" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
 "hp" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Public EVA"
-	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "E.V.A. Storage";
+	req_access_txt = "18"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "hq" = (
@@ -2216,27 +2302,18 @@
 /obj/effect/turf_decal/tile/ship/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/yellow,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "ht" = (
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/ship/orange,
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck2/primary)
-"hv" = (
-/obj/structure/grille,
-/obj/effect/turf_decal/tile/ship/yellow{
+/obj/effect/turf_decal/tile/ship/orange{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/blue,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "hw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2314,20 +2391,15 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck2/port)
 "hH" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/engine/atmos)
-"hI" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/ship/techfloor{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/orange{
+/obj/effect/turf_decal/tile/ship/half/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/orange,
-/obj/machinery/deck_turret/powder_gate,
-/turf/open/floor/plating,
-/area/nsv/weapons)
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "hK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -2371,6 +2443,19 @@
 "hP" = (
 /turf/open/floor/plasteel/grid/techfloor,
 /area/maintenance/nsv/deck2/starboard)
+"hR" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/break_room)
+"hT" = (
+/obj/machinery/computer/atmos_control/tank/carbon_tank{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "hV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2433,18 +2518,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
-"ig" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/nsv/weapons)
 "ih" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/cargo_technician,
@@ -2455,24 +2528,25 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
-"im" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/engine_room)
 "in" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
 /obj/item/extinguisher/advanced/hull_repair_juice,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"io" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engine_room)
 "ir" = (
 /turf/open/floor/plasteel/grid/techfloor,
 /area/maintenance/nsv/deck2/port)
@@ -2483,9 +2557,12 @@
 	name = "Abandoned Bar"
 	})
 "iu" = (
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
+	name = "Air to distro";
+	target_pressure = 2000
+	},
+/obj/machinery/atmospherics/components/trinary/mixer/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -2518,11 +2595,19 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "iA" = (
-/obj/machinery/computer/ship/munitions_computer/west{
-	dir = 4
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
+/obj/item/construction/rcd,
+/obj/item/construction/rcd,
+/obj/item/construction/rcd,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/structure/rack,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "iC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2530,15 +2615,15 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "iD" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/trunk/multiz{
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/ship/techfloor{
 	dir = 8
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "iE" = (
 /obj/machinery/suit_storage_unit/pilot,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -2567,6 +2652,7 @@
 	name = "strange cube"
 	},
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "iP" = (
@@ -2626,13 +2712,15 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck2/port/fore)
 "iW" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "iX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -2643,7 +2731,7 @@
 "iY" = (
 /obj/structure/sign/ship/nosmoking,
 /turf/closed/wall/r_wall,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "ja" = (
 /obj/structure/fighter_launcher/launch_only{
 	dir = 4;
@@ -2684,11 +2772,11 @@
 /turf/open/floor/engine,
 /area/quartermaster/storage)
 "je" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
+	dir = 4;
+	id = "sdmix_in"
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "jf" = (
 /obj/structure/disposalpipe/segment{
@@ -2704,10 +2792,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck2/starboard)
-"jh" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "jl" = (
 /obj/structure/stairs{
 	dir = 8
@@ -2736,12 +2820,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
@@ -2837,6 +2923,12 @@
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery/deck2/port)
+"jB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light/small,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/chief)
 "jC" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -2869,9 +2961,13 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "jI" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input,
-/obj/machinery/camera/autoname,
-/turf/open/floor/engine/n2,
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 1
+	},
+/turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "jK" = (
 /obj/machinery/computer/operating{
@@ -2900,12 +2996,18 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
 "jP" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
-	dir = 1
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "jQ" = (
 /turf/open/floor/carpet/red,
 /area/security/brig)
@@ -2935,8 +3037,8 @@
 /area/engine/engine_room)
 "jX" = (
 /obj/structure/lattice/catwalk/over/ship,
-/obj/structure/chair/office{
-	dir = 4
+/obj/machinery/computer/ams{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
@@ -3121,21 +3223,17 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
-"ky" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+"kw" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
+"ky" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port/fore)
 "kz" = (
 /obj/structure/table/wood,
 /obj/machinery/door/poddoor/shutters/ship{
@@ -3175,10 +3273,6 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/techmaint,
 /area/security/prison)
-"kC" = (
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
 "kD" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -3242,7 +3336,7 @@
 "kK" = (
 /obj/structure/sign/ship/deck/two,
 /turf/closed/wall/r_wall,
-/area/nsv/weapons)
+/area/quartermaster/qm)
 "kL" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -3261,26 +3355,16 @@
 /turf/open/floor/plasteel/techmaint,
 /area/security/prison)
 "kN" = (
-/obj/effect/turf_decal/box/corners,
-/obj/machinery/conveyor_switch{
-	id = "atlas_naval";
-	name = "Naval Cannon Ammunition Line"
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
-"kO" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck2/primary)
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
+"kO" = (
+/obj/structure/chair/stool,
+/obj/structure/munitions_trolley,
+/turf/open/floor/carpet/red,
+/area/nsv/weapons)
 "kP" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/cable{
@@ -3291,9 +3375,20 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "kQ" = (
-/obj/machinery/computer/ship/munitions_computer/west,
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "kT" = (
 /obj/vehicle/ridden/janicart,
 /obj/item/key/janitor,
@@ -3366,15 +3461,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "ld" = (
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/table/wood/fancy/orange,
+/obj/item/reagent_containers/food/drinks/solgovcup{
+	pixel_x = 8;
+	pixel_y = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/zebra_interlock_point,
+/obj/item/reagent_containers/food/snacks/snowcones/clown,
 /turf/open/floor/monotile/steel,
-/area/maintenance/nsv/deck2/starboard)
+/area/engine/break_room)
 "le" = (
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -3387,28 +3481,40 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "lf" = (
-/obj/structure/rack,
-/obj/item/powder_bag{
-	pixel_y = -10
-	},
-/obj/item/powder_bag{
-	pixel_y = -10
+/obj/machinery/ammo_sorter{
+	dir = 4;
+	id = "atlas2";
+	name = "Gunpowder"
 	},
 /obj/item/powder_bag,
 /obj/item/powder_bag,
-/obj/item/powder_bag{
-	pixel_y = 8
-	},
-/obj/item/powder_bag{
-	pixel_y = 8
-	},
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "lh" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1;
+	icon_state = "bordercorner"
+	},
+/turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "li" = (
 /obj/machinery/armour_plating_nanorepair_pump/forward_starboard{
@@ -3421,11 +3527,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/monotile/dark,
 /area/science)
-"lm" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/engine/atmos)
 "ln" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3446,13 +3547,17 @@
 /turf/open/floor/monotile/dark,
 /area/science)
 "lo" = (
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/yellow,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "lp" = (
@@ -3475,11 +3580,18 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "lt" = (
-/obj/machinery/computer/ams{
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
 	dir = 8
 	},
-/turf/open/floor/carpet/red,
-/area/nsv/weapons)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "lu" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
@@ -3495,20 +3607,10 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "lw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Engineering wing maintenance";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/ship/orange,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "lx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3572,14 +3674,12 @@
 "lC" = (
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/nsv/deck2/primary)
-"lD" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
+"lE" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
 	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/engine/plasma,
+/turf/open/floor/engine/co2,
 /area/engine/atmos)
 "lF" = (
 /obj/machinery/airalarm/directional/east,
@@ -3599,6 +3699,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engine_room)
+"lJ" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "lK" = (
 /obj/item/control_rod,
 /turf/open/indestructible/sound/pool/spentfuel/wall,
@@ -3677,13 +3781,9 @@
 /area/science)
 "lW" = (
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
 /obj/machinery/power/deck_relay,
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "lX" = (
@@ -3693,15 +3793,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "2-9"
 	},
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plating,
-/area/engine/atmos)
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "lY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "lZ" = (
@@ -3722,8 +3822,17 @@
 /area/science)
 "mf" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Engineering wing maintenance";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "mg" = (
@@ -3732,14 +3841,41 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "mj" = (
-/turf/open/floor/plating,
-/area/engine/atmos)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "mk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"mn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "mp" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -3772,9 +3908,15 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plating,
-/area/engine/atmos)
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "ms" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -3792,15 +3934,30 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"mw" = (
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/item/book/manual/wiki/rbmk,
+/obj/machinery/light_switch/west{
+	pixel_y = 12
+	},
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/chief)
+"mx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "my" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
@@ -3878,7 +4035,15 @@
 /turf/open/indestructible/sound/pool/spentfuel,
 /area/engine/engine_room)
 "mJ" = (
-/obj/machinery/portable_atmospherics/pump,
+/obj/structure/closet/toolcloset,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "mK" = (
@@ -3909,67 +4074,87 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "mR" = (
-/obj/machinery/door/airlock/ship/maintenance,
+/obj/structure/stairs{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
+"mS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
-"mS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "mU" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/engine/engine_room)
+/area/maintenance/department/engine/atmos)
 "mV" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 10
 	},
-/obj/machinery/computer/atmos_control/tank/nitrous_tank,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "mX" = (
 /turf/open/floor/carpet/orange,
 /area/engine/engine_room)
 "mY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
-/turf/open/floor/plating,
-/area/engine/atmos)
-"mZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"mZ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input,
+/obj/machinery/camera/autoname,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "nc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/ship/techfloor,
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
+"nd" = (
+/obj/machinery/door/airlock/ship/command{
+	name = "Master At Arms";
+	req_one_access_txt = "70"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/ammo_sorter{
-	id = "atlas1";
-	name = "Gunpowder #2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/item/powder_bag,
-/obj/item/powder_bag,
-/obj/item/powder_bag,
-/obj/item/powder_bag,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "nh" = (
@@ -3985,15 +4170,10 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/engine/engine_room)
 "nj" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "atlas_powder";
-	name = "Feed Powder Racks"
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input,
+/obj/machinery/camera/autoname,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "nk" = (
 /obj/machinery/squad_vendor,
 /turf/closed/wall/r_wall,
@@ -4064,11 +4244,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nu" = (
-/obj/item/relic,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
+/obj/machinery/camera/autoname,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "nw" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4139,34 +4318,42 @@
 /area/nsv/weapons)
 "nD" = (
 /obj/item/stock_parts/scanning_module,
+/obj/item/trash/raisins,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "nF" = (
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
+	},
 /obj/machinery/light{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/conveyor/inverted{
-	dir = 5;
-	id = "atlas_naval"
-	},
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "nG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"nH" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+/obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
+"nH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
+	dir = 8;
+	id_tag = "sdmix_out"
+	},
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos)
 "nI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4192,53 +4379,35 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "nK" = (
-/obj/structure/closet/secure_closet/quartermaster,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/item/bedsheet/qm,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/quartermaster/qm)
 "nL" = (
-/obj/structure/disposalpipe/trunk,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/button/massdriver{
+	id = "disposalgun";
+	pixel_x = -20;
+	pixel_y = -1;
+	req_one_access_txt = "12"
 	},
-/obj/structure/disposaloutlet{
+/obj/structure/chair{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
-"nM" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer1{
-	name = "Air to distro";
-	target_pressure = 2000
+"nN" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 10
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/layer3{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"nN" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor{
-	dir = 8;
-	piping_layer = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "nO" = (
@@ -4262,10 +4431,21 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "nT" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
 	},
-/obj/machinery/meter/atmos,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "nU" = (
@@ -4282,20 +4462,50 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "nZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/door/airlock/ship/engineering/glass{
+	name = "Atmospherics";
+	req_one_access_txt = "24;10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ob" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/starboard)
 "oc" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
-	dir = 8;
-	piping_layer = 1
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "Public EVA"
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
-/turf/open/floor/plating,
-/area/engine/atmos)
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "oe" = (
 /obj/item/chair,
 /turf/open/floor/wood{
@@ -4316,7 +4526,6 @@
 /obj/effect/turf_decal/pool{
 	dir = 1
 	},
-/obj/effect/landmark/start/depsec/engineering,
 /obj/machinery/light_switch/east,
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
@@ -4338,7 +4547,7 @@
 /turf/open/floor/monotile/steel,
 /area/science)
 "om" = (
-/obj/machinery/vending/engivend,
+/obj/machinery/vending/coffee,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "oo" = (
@@ -4375,17 +4584,15 @@
 	name = "Abandoned Bar"
 	})
 "or" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 5;
-	icon_state = "pipe11-1"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "os" = (
-/obj/structure/closet/secure_closet/genpop,
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
@@ -4395,7 +4602,8 @@
 	id = "atlas_perma";
 	pixel_x = -32
 	},
-/obj/item/clothing/under/rank/prisoner,
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
 /turf/open/floor/plasteel/techmaint,
 /area/security/brig)
 "ot" = (
@@ -4406,9 +4614,6 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
 "ov" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -4425,22 +4630,20 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "oB" = (
-/obj/structure/rack,
-/obj/item/construction/rcd,
-/obj/item/construction/rcd,
-/obj/item/construction/rcd,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
-/obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 8;
-	icon_state = "borderhalf"
+/obj/machinery/firealarm/directional/east,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/stamp/ce,
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = -5;
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 4
+/obj/item/pen/fountain,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
+/area/crew_quarters/heads/chief)
 "oC" = (
 /obj/item/control_rod,
 /obj/machinery/light{
@@ -4464,11 +4667,11 @@
 /turf/closed/wall/steel,
 /area/engine/engine_room)
 "oG" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "oH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4482,6 +4685,23 @@
 "oI" = (
 /turf/closed/wall/r_wall,
 /area/chapel/main)
+"oL" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/obj/machinery/recycler,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "oM" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk,
@@ -4554,13 +4774,6 @@
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
-"oW" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "oX" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -4613,31 +4826,16 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "pd" = (
-/obj/item/paper_bin/construction,
-/obj/item/pen/fountain,
-/obj/machinery/button/door{
-	id = "gaussgang_atlas";
-	name = "public gauss access";
-	pixel_y = 32;
-	req_one_access_txt = "69"
+/obj/structure/table/wood/fancy/black,
+/obj/item/megaphone/cargo,
+/obj/item/clothing/head/soft{
+	pixel_x = 7;
+	pixel_y = 8
 	},
-/obj/machinery/button/door{
-	id = "muni_atlas";
-	name = "public munitions access";
-	pixel_y = 24;
-	req_one_access_txt = "69"
-	},
-/obj/structure/closet/secure_closet/master_at_arms,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Master At Arms' Desk";
-	departmentType = 5;
-	name = "Master at Arms RC";
-	pixel_x = 32
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons)
+/obj/item/clothing/neck/cloak/qm,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/quartermaster/qm)
 "pe" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -4650,25 +4848,25 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
-"pk" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
+"pk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "pl" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4676,13 +4874,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hmains1";
 	location = "hmains3"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -4752,16 +4953,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
-"pt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/blue,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "pw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -4856,7 +5047,10 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "pH" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/sign/directions/science,
+/obj/structure/sign/directions/supply{
+	pixel_y = -6
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "pJ" = (
@@ -4875,6 +5069,10 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
+"pM" = (
+/obj/machinery/computer/arcade/amputation,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "pO" = (
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss/battery/deck2/port)
@@ -4894,31 +5092,19 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "pT" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/monotile/dark,
+/obj/structure/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "pU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/ammo_sorter{
-	dir = 4;
-	id = "atlas1";
-	name = "Standard Shells #1"
-	},
-/obj/item/ship_weapon/ammunition/naval_artillery,
-/obj/item/ship_weapon/ammunition/naval_artillery,
-/obj/item/ship_weapon/ammunition/naval_artillery,
-/turf/open/floor/monotile/dark,
+/obj/item/bedsheet/orange,
+/obj/structure/bed/pod,
+/obj/machinery/computer/ship/viewscreen,
+/turf/open/floor/carpet/royalblack,
 /area/nsv/weapons)
 "pV" = (
 /obj/machinery/button/door{
@@ -4953,26 +5139,18 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pZ" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/monotile/dark,
+/obj/structure/rack,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "qa" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "qb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -4994,18 +5172,15 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "qd" = (
-/obj/machinery/button/massdriver{
-	id = "disposalgun";
-	pixel_x = -20;
-	pixel_y = -1;
-	req_one_access_txt = "12"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "qe" = (
-/obj/machinery/vending/tool,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
@@ -5046,6 +5221,11 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
+"qk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/closed/wall/steel,
+/area/crew_quarters/heads/chief)
 "ql" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -5101,11 +5281,12 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "qw" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tank - Mix";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
+	dir = 4
 	},
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "qx" = (
 /obj/structure/cable/yellow{
@@ -5173,41 +5354,41 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "E.V.A. Storage";
-	req_access_txt = "18"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "Chief Engineer";
+	req_one_access_txt = "56"
+	},
 /turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
+/area/crew_quarters/heads/chief)
 "qQ" = (
-/obj/machinery/deck_turret/autoelevator,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
 /obj/effect/turf_decal/tile/ship/orange,
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 8
-	},
+/obj/machinery/deck_turret/powder_gate,
 /turf/open/floor/plating,
 /area/nsv/weapons)
+"qS" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/obj/machinery/light/small,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "qT" = (
 /turf/closed/wall/steel,
 /area/nsv/weapons/gauss/battery/deck2/starboard)
-"qU" = (
-/obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 4;
-	icon_state = "borderhalf"
-	},
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
 "qY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -5265,40 +5446,29 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "rh" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/rack,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "ri" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/closet/secure_closet/master_at_arms,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/machinery/ammo_sorter{
-	dir = 4;
-	id = "atlas1";
-	name = "Standard Shells #2"
-	},
-/obj/item/ship_weapon/ammunition/naval_artillery,
-/obj/item/ship_weapon/ammunition/naval_artillery,
-/obj/item/ship_weapon/ammunition/naval_artillery,
-/turf/open/floor/monotile/dark,
+/turf/open/floor/carpet/royalblack,
 /area/nsv/weapons)
 "rj" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_room)
 "rl" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/conveyor{
-	dir = 4;
+/obj/machinery/conveyor/inverted{
+	dir = 9;
 	id = "atlas_naval"
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "rn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -5313,40 +5483,55 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "ro" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
-	dir = 8;
-	id_tag = "sdmix_out"
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "rq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/lattice/catwalk/over/ship,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "rr" = (
-/obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 4;
-	icon_state = "borderhalf"
-	},
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/suit_storage_unit/captain,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
-"ru" = (
-/obj/structure/grille/broken,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/closet/crate/engineering,
-/obj/effect/spawner/lootdrop/maintenance/six,
-/obj/effect/spawner/lootdrop/gloves,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/computer/card/minor/ce{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 4
+	},
+/mob/living/simple_animal/parrot/Poly,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/heads/chief)
+"rt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
+"ru" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "rv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -5357,17 +5542,19 @@
 	name = "Abandoned Bar"
 	})
 "rx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 4
-	},
+/obj/machinery/meter/atmos/distro_loop,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ry" = (
 /obj/structure/closet/radiation,
 /obj/item/geiger_counter,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "rz" = (
@@ -5436,20 +5623,27 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "rJ" = (
-/obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 4;
-	icon_state = "borderhalf"
-	},
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/ce,
+/obj/machinery/light_switch/west{
+	pixel_y = 12
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -25;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 4
+	},
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
+/area/crew_quarters/heads/chief)
 "rK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -5556,15 +5750,7 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss/battery/deck2/starboard)
 "rX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 8
-	},
+/obj/machinery/deck_turret,
 /turf/open/floor/plating,
 /area/nsv/weapons)
 "rZ" = (
@@ -5584,12 +5770,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "sa" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/computer/cargo{
+	dir = 4
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons)
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/quartermaster/qm)
 "se" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -5641,6 +5826,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
+"sk" = (
+/obj/structure/trap/stun/hunter,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "sl" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/machinery/door/firedoor/border_only{
@@ -5727,11 +5916,11 @@
 	name = "Abandoned Bar"
 	})
 "sP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/area/maintenance/nsv/deck2/starboard)
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "sQ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -5742,6 +5931,9 @@
 	},
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
@@ -5755,13 +5947,15 @@
 /obj/effect/turf_decal/tile/ship/yellow{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "sU" = (
-/obj/effect/spawner/room/fivexfour,
-/turf/template_noop,
-/area/maintenance/nsv/deck2/starboard)
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "sV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -5779,6 +5973,19 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"tc" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "td" = (
 /turf/open/floor/monotile/steel,
 /area/science)
@@ -5795,12 +6002,13 @@
 /turf/open/floor/monotile/dark,
 /area/science)
 "tg" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
-	dir = 8;
-	icon_state = "filter_on"
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 4;
+	icon_state = "pipe11-1"
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -5846,19 +6054,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
-"tn" = (
-/obj/machinery/computer/deckgun,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/nsv/weapons)
 "tp" = (
 /turf/open/floor/engine,
 /area/science)
@@ -5976,13 +6171,19 @@
 /turf/open/floor/plasteel/techmaint,
 /area/security/prison)
 "tA" = (
-/obj/machinery/computer/atmos_control/tank/oxygen_tank,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 6;
-	icon_state = "pipe11-1"
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
+	name = "Nitrogen to Air Mix";
+	target_pressure = 2000
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	name = "Nitrogen to mix"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 4;
+	icon_state = "pipe11-1"
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -5990,12 +6191,21 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/machinery/computer/bounty{
-	dir = 4;
-	layer = 2.88
-	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/quartermaster/qm)
+"tC" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "tG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6007,11 +6217,11 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss/battery/deck2/port)
 "tJ" = (
-/obj/structure/chair,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/nsv/deck2/starboard)
+/obj/structure/extinguisher_cabinet/west,
+/obj/machinery/airalarm/directional/south,
+/obj/item/toy/plush/renault,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/chief)
 "tL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
@@ -6110,6 +6320,17 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
+"uh" = (
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/machinery/conveyor{
+	dir = 6;
+	id = "atlas_gunpowder"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "ui" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/chair/stool,
@@ -6129,7 +6350,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "um" = (
@@ -6234,11 +6454,18 @@
 /turf/open/floor/engine,
 /area/quartermaster/storage)
 "uz" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
 /obj/machinery/light/small{
 	brightness = 3
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/red,
+/obj/item/stack/cable_coil/red,
+/obj/item/stack/cable_coil/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
@@ -6283,13 +6510,16 @@
 	name = "Abandoned Bar"
 	})
 "uG" = (
+/obj/machinery/deck_turret/autoelevator,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 1
 	},
-/obj/machinery/deck_turret/payload_gate,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/nsv/weapons)
 "uI" = (
@@ -6299,15 +6529,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
-"uJ" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "uL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6339,6 +6560,22 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"uQ" = (
+/obj/machinery/firealarm/directional/east,
+/obj/item/bedsheet/ce,
+/obj/structure/bed/pod,
+/obj/machinery/computer/security/telescreen/ce{
+	pixel_y = 26
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 4;
+	name = "Chief Engineer RC";
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/chief)
 "uR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -6371,16 +6608,13 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "uY" = (
-/obj/machinery/deck_turret/autoelevator,
 /obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 1
+	dir = 10
 	},
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
 	},
+/obj/machinery/deck_turret/powder_gate,
 /turf/open/floor/plating,
 /area/nsv/weapons)
 "uZ" = (
@@ -6423,12 +6657,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "vi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "vj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -6465,6 +6696,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "vo" = (
@@ -6497,25 +6731,11 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "vw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/mineral/stacking_machine,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "vC" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -6543,20 +6763,12 @@
 	})
 "vF" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 8
 	},
-/obj/machinery/ammo_sorter{
-	id = "atlas1";
-	name = "Gunpowder #1"
-	},
-/obj/item/powder_bag,
-/obj/item/powder_bag,
-/obj/item/powder_bag,
-/obj/item/powder_bag,
-/turf/open/floor/monotile/dark,
+/turf/open/floor/plating,
 /area/nsv/weapons)
 "vG" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6570,28 +6782,31 @@
 /turf/open/floor/plating,
 /area/science)
 "vH" = (
-/obj/machinery/computer/atmos_control/tank/mix_tank{
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "vJ" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
+/obj/machinery/atmospherics/components/binary/pump/on/layer1{
+	name = "Oxygen to Air Mix";
+	target_pressure = 2000
 	},
-/obj/machinery/recycler,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	name = "Oxygen to mixtape"
 	},
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/area/engine/atmos)
+"vK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "vM" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/extinguisher_cabinet/east,
@@ -6612,6 +6827,18 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"vS" = (
+/obj/structure/chair/sofa/right{
+	dir = 8;
+	icon_state = "sofaend_right"
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
+	},
+/obj/machinery/light_switch/east,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "vT" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
@@ -6642,19 +6869,26 @@
 /turf/open/floor/plasteel/grid/techfloor/grid,
 /area/security/prison)
 "vW" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/machinery/computer/atmos_control/tank/oxygen_tank,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 6;
+	icon_state = "pipe11-1"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "vX" = (
-/obj/machinery/light/small{
-	brightness = 3;
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 8;
+	icon_state = "filter_on"
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1{
 	dir = 1
 	},
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/area/engine/atmos)
 "vY" = (
 /obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 1
@@ -6672,15 +6906,15 @@
 	name = "Abandoned Bar"
 	})
 "wa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/conveyor/inverted{
+	dir = 5;
+	id = "atlas_naval"
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "wb" = (
 /obj/machinery/armour_plating_nanorepair_pump/forward_port{
 	apnw_id = "atlas_comedy"
@@ -6696,6 +6930,14 @@
 "wd" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/port)
+"we" = (
+/obj/structure/ladder,
+/obj/structure/sign/ship/space{
+	name = "WARNING: SPACE LADDER";
+	pixel_y = -24
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "wh" = (
 /obj/machinery/light{
 	dir = 8
@@ -6765,6 +7007,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"ww" = (
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "wx" = (
 /turf/open/floor/plasteel/ridged/steel,
 /area/hallway/nsv/deck2/primary)
@@ -6776,6 +7025,9 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"wz" = (
+/turf/closed/wall/r_wall,
+/area/engine/break_room)
 "wA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -6786,17 +7038,8 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "wC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/blue,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos)
 "wE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6860,6 +7103,7 @@
 	name = "\improper Community Manager's Cigarettes"
 	},
 /obj/machinery/light_switch/east,
+/obj/effect/spawner/bundle/costume/maid,
 /turf/open/floor/plasteel/grid/lino,
 /area/janitor)
 "wO" = (
@@ -6880,6 +7124,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
+"wP" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "wQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -6938,6 +7189,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
+"wY" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
+"wZ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "xa" = (
 /obj/structure/cable{
 	icon_state = "6-8"
@@ -6956,12 +7220,16 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "xd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output,
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide{
-	valve_open = 1
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "atlas_powder"
 	},
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "atlas_naval"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "xg" = (
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
 /turf/open/floor/plating,
@@ -6973,13 +7241,15 @@
 /turf/open/floor/engine,
 /area/science)
 "xk" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "atlas_specialshells"
+/obj/machinery/door/airlock/ship/command{
+	name = "Master At Arms";
+	req_one_access_txt = "70"
 	},
-/obj/machinery/conveyor{
-	id = "atlas_naval"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "xm" = (
@@ -6997,15 +7267,10 @@
 /turf/open/floor/plasteel/techmaint,
 /area/science)
 "xq" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 4
 	},
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	name = "Atmospherics RC";
-	pixel_y = -30
-	},
+/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "xr" = (
@@ -7059,9 +7324,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Engineering";
+	req_one_access = null;
+	req_one_access_txt = "10"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/lattice/catwalk/over/ship{
+	color = "#868B9C"
+	},
+/turf/open/floor/plating,
+/area/engine/break_room)
 "xB" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/tile/ship/red,
@@ -7105,19 +7384,17 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "xI" = (
-/obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/effect/turf_decal/tile/ship/yellow{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/blue,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/nsv/weapons)
 "xK" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -7182,11 +7459,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "xT" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/light,
+/obj/structure/munitions_trolley,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "xX" = (
@@ -7254,22 +7532,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "yr" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
-	},
-/obj/machinery/door/window/southright{
-	dir = 1;
-	name = "Disposals"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/obj/machinery/computer/ship/munitions_computer/west,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "ys" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7357,6 +7622,13 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck2/port)
+"yJ" = (
+/obj/structure/reagent_dispensers/foamtank/hull_repair_juice,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "yL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -7405,21 +7677,23 @@
 	},
 /turf/closed/wall/r_wall,
 /area/quartermaster/storage)
+"yT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "yU" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Engineering wing maintenance";
-	req_one_access_txt = "10;24"
+/obj/machinery/computer/ship/munitions_computer/west{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/structure/lattice/catwalk/over/ship,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "yW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -7454,13 +7728,9 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/nsv/deck2/primary)
 "yZ" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 1
-	},
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "za" = (
 /turf/open/floor/monotile/steel,
@@ -7484,7 +7754,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "zh" = (
@@ -7545,31 +7817,13 @@
 	name = "Abandoned Bar"
 	})
 "zo" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/obj/structure/lattice/catwalk,
+/obj/structure/grille/wall,
+/turf/open/space/basic,
+/area/engine/engine_room)
 "zq" = (
-/obj/machinery/conveyor{
-	dir = 6;
-	id = "cmbelt"
-	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -7641,6 +7895,18 @@
 /obj/item/ship_weapon/parts/missile/propulsion_system,
 /turf/open/floor/engine,
 /area/nsv/weapons)
+"zN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/nsv/weapons)
 "zO" = (
 /obj/machinery/door/poddoor/shutters/ship{
 	dir = 4;
@@ -7681,6 +7947,14 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"zS" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/obj/item/extinguisher/mini,
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "zU" = (
 /obj/structure/table/reinforced,
 /obj/item/lighter,
@@ -7787,17 +8061,18 @@
 	brightness = 3;
 	dir = 1
 	},
-/obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "Am" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "Ao" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -7820,20 +8095,24 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "Ax" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/machinery/door/airlock/ship/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "24;10"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/engine,
+/turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "Az" = (
 /obj/machinery/door/firedoor/border_only{
@@ -7858,12 +8137,8 @@
 /area/security/prison)
 "AL" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 5;
+	dir = 4;
 	icon_state = "pipe11-1"
-	},
-/obj/structure/extinguisher_cabinet/west,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 6
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -7897,13 +8172,12 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
 "AU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/disposalpipe/trunk/multiz,
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "Ba" = (
@@ -7955,6 +8229,31 @@
 "Bj" = (
 /turf/open/floor/monotile/dark,
 /area/science)
+"Bk" = (
+/obj/machinery/ammo_sorter{
+	dir = 8;
+	id = "atlas2";
+	name = "Gunpowder"
+	},
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "Bs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -7962,6 +8261,19 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/qm)
+"Bu" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/snacks/spacetwinkie,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "Bv" = (
 /obj/structure/rack,
 /obj/machinery/gauss_dispenser{
@@ -7986,11 +8298,13 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "Bx" = (
-/obj/machinery/computer/cargo{
-	dir = 4
+/obj/machinery/button/door{
+	id = "reactorld19";
+	name = "Shutters button";
+	pixel_x = 24
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/quartermaster/qm)
+/turf/open/floor/monotile/steel,
+/area/engine/engine_room)
 "By" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -8001,9 +8315,11 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "BC" = (
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	name = "N20 to remix"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4;
@@ -8019,13 +8335,25 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/security/prison)
-"BG" = (
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	dir = 1;
-	name = "Co2 to MEGAmix"
+"BE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/camera/autoname{
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/hallway/nsv/deck2/primary)
+"BG" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
+	},
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	name = "Atmospherics RC";
+	pixel_y = -30
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -8039,14 +8367,10 @@
 /turf/open/floor/monotile/dark,
 /area/science)
 "BI" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "atlas_standardshell"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/conveyor{
-	id = "atlas_naval"
-	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/carpet/royalblack,
 /area/nsv/weapons)
 "BJ" = (
 /obj/structure/particle_accelerator/particle_emitter/right{
@@ -8064,6 +8388,26 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"BK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/mineral/stacking_machine,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "BM" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -8109,13 +8453,10 @@
 	name = "Abandoned Bar"
 	})
 "BR" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/engine/co2,
+/obj/machinery/atmospherics/miner/toxins,
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/obj/machinery/light/small,
+/turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "BS" = (
 /obj/structure/chair{
@@ -8127,9 +8468,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "BU" = (
-/turf/closed/wall/r_wall{
-	layer = 2.91
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "BW" = (
 /obj/structure/disposalpipe/segment{
@@ -8192,6 +8535,12 @@
 /obj/item/ship_weapon/parts/missile/iff_card,
 /turf/open/floor/carpet/red,
 /area/nsv/weapons)
+"Cg" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "Ci" = (
 /obj/machinery/cell_charger,
 /obj/item/storage/toolbox/mechanical{
@@ -8273,8 +8622,14 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "Cv" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 5;
+	icon_state = "pipe11-1"
+	},
+/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -8295,6 +8650,15 @@
 "CA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/dark,
+/area/nsv/weapons)
+"CB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/nsv/weapons)
 "CC" = (
 /obj/effect/turf_decal/delivery,
@@ -8334,7 +8698,14 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/hallway/nsv/deck2/primary)
 "CG" = (
-/obj/machinery/deck_turret,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/machinery/deck_turret/powder_gate,
 /turf/open/floor/plating,
 /area/nsv/weapons)
 "CH" = (
@@ -8354,6 +8725,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"CQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "CR" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -8405,6 +8783,14 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"CX" = (
+/obj/structure/rack,
+/obj/item/extinguisher/advanced/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
+/obj/item/extinguisher/advanced/hull_repair_juice,
+/obj/machinery/light_switch/south,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "CY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -8422,9 +8808,11 @@
 /turf/open/floor/carpet/ship,
 /area/nsv/hanger/notkmcstupidhanger)
 "Dd" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
-/obj/machinery/camera/autoname,
-/turf/open/floor/engine/n2o,
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - Mix";
+	dir = 8
+	},
+/turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "De" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -8432,22 +8820,30 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
 "Di" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	density = 0;
+	dir = 4;
+	input_tag = "sdmix_in";
+	name = "Reactor Mix Control";
+	output_tag = "sdmix_out";
+	pixel_x = -9;
+	sensors = list("sdmix_sensor" = "Reactor Mix Tank")
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"Dj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/ammo_sorter{
-	dir = 4;
-	id = "atlas1";
-	name = "AP shells"
-	},
-/obj/item/ship_weapon/ammunition/naval_artillery/ap,
-/obj/item/ship_weapon/ammunition/naval_artillery/ap,
-/obj/item/ship_weapon/ammunition/naval_artillery/ap,
-/obj/item/ship_weapon/ammunition/naval_artillery/ap,
-/obj/item/ship_weapon/ammunition/naval_artillery/ap,
-/obj/item/ship_weapon/ammunition/naval_artillery/ap,
-/turf/open/floor/monotile/dark,
+/turf/open/floor/plating,
 /area/nsv/weapons)
 "Dk" = (
 /obj/structure/lattice/catwalk/over/ship,
@@ -8537,16 +8933,23 @@
 "Dy" = (
 /turf/closed/wall/r_wall,
 /area/quartermaster/qm)
-"DD" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 1
+"DB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/ship/engineering{
+	name = "Engineering";
+	req_one_access = null;
+	req_one_access_txt = "10"
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/area/engine/break_room)
+"DD" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "DG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8554,8 +8957,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
+"DH" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
+"DK" = (
+/obj/structure/rack,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/machinery/light,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "DM" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -8569,11 +8987,20 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
-"DT" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
+"DQ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
+	dir = 1
 	},
-/obj/structure/munitions_trolley,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
+"DT" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "atlas_naval"
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "DU" = (
@@ -8640,11 +9067,8 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "Eg" = (
-/obj/structure/sign/ship/deck/two{
-	dir = 8
-	},
-/turf/closed/wall/steel,
-/area/hallway/nsv/deck2/primary)
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/chief)
 "Eh" = (
 /obj/effect/turf_decal/tile/ship/half/red{
 	dir = 8
@@ -8694,6 +9118,16 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
+"Es" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "Et" = (
 /obj/structure/shuttle/engine/huge{
 	dir = 8
@@ -8706,6 +9140,14 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"Ew" = (
+/obj/machinery/door/poddoor{
+	id = "dispo";
+	name = "Disposal Shutter"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "Ex" = (
 /obj/structure/chair,
 /turf/open/floor/wood,
@@ -8729,19 +9171,31 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "EB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+/obj/structure/table,
+/obj/item/storage/box/cups,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera/autoname{
+/obj/effect/turf_decal/tile/ship/yellow{
 	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
-/area/engine/atmos)
+/obj/effect/turf_decal/tile/ship/yellow,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
+"ED" = (
+/obj/machinery/computer/ship/ordnance,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "EE" = (
 /turf/template_noop,
 /area/maintenance/nsv/deck2/port/fore)
 "EG" = (
-/obj/structure/table/reinforced,
 /obj/item/cartridge/quartermaster{
 	pixel_x = 6;
 	pixel_y = 5
@@ -8758,14 +9212,40 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
-/obj/item/clothing/neck/cloak/qm,
-/obj/item/clothing/head/soft{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/megaphone/cargo,
+/obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/quartermaster/qm)
+"EH" = (
+/obj/machinery/light,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
+"EJ" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
+"EN" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
+"EO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "ER" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -8797,6 +9277,15 @@
 	},
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/hanger/notkmcstupidhanger)
+"Fa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "Ff" = (
 /obj/machinery/button/door{
 	id = "sermon_shutters";
@@ -8811,18 +9300,13 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/chapel/main)
 "Fg" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
-	dir = 8;
-	icon_state = "filter_on"
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+	dir = 10
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 1
-	},
+/obj/machinery/computer/atmos_control/tank/nitrous_tank,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Fh" = (
@@ -8888,6 +9372,10 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/nsv/hanger/notkmcstupidhanger)
+"Fp" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "Fq" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/disposalpipe/segment{
@@ -8924,22 +9412,15 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "FA" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/lattice/catwalk/over/ship,
-/turf/open/floor/monotile/steel,
-/area/nsv/weapons)
-"FB" = (
-/obj/machinery/meter/atmos/distro_loop,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "FE" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons)
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/quartermaster/qm)
 "FF" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -8969,6 +9450,16 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
+"FK" = (
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/yellow,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "FL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9023,14 +9514,14 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "FU" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
@@ -9070,9 +9561,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
@@ -9109,10 +9597,14 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
-	sortType = 6
+	sortType = null;
+	sortTypes = list(6,32)
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -9127,30 +9619,33 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Engineering wing maintenance";
-	req_one_access_txt = "10"
+/obj/machinery/door/airlock/ship/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "24;10"
 	},
+/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/lattice/catwalk/over/ship{
+	color = "#868B9C"
+	},
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/area/engine/break_room)
 "Gm" = (
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Gp" = (
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/monotile/steel,
-/area/maintenance/nsv/deck2/starboard)
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "Gq" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -9169,6 +9664,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "Gt" = (
@@ -9178,12 +9676,11 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Gu" = (
-/obj/machinery/conveyor/inverted{
-	dir = 9;
-	id = "atlas_naval"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
+/turf/open/floor/plating,
+/area/engine/atmos)
 "Gw" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light_switch/west,
@@ -9199,6 +9696,10 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/science)
+"Gz" = (
+/obj/structure/sign/poster/contraband/syndicate_recruitment,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "GA" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9207,10 +9708,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "GB" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 4
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 1
 	},
-/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "GC" = (
@@ -9270,22 +9770,31 @@
 /turf/open/floor/engine,
 /area/quartermaster/storage)
 "GK" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "atlas_naval"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/monotile/steel,
-/area/nsv/weapons)
-"GM" = (
-/obj/structure/chair/office{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
+/obj/machinery/ammo_sorter{
+	dir = 4;
+	id = "atlas1";
+	name = "Standard Shells #1"
 	},
-/obj/effect/landmark/start/master_at_arms,
-/turf/open/floor/carpet/ship,
+/obj/item/ship_weapon/ammunition/naval_artillery,
+/obj/item/ship_weapon/ammunition/naval_artillery,
+/obj/item/ship_weapon/ammunition/naval_artillery,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
+"GM" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "atlas_standardshell";
+	name = "Load Standard Shells"
+	},
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "GN" = (
 /obj/structure/table,
@@ -9401,6 +9910,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"Hm" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "Hr" = (
 /obj/machinery/autolathe,
 /obj/machinery/power/apc/auto_name/east,
@@ -9456,6 +9969,12 @@
 	dir = 1
 	},
 /area/chapel/main)
+"Hz" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "HA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -9521,42 +10040,20 @@
 /turf/closed/wall/steel,
 /area/hallway/nsv/deck2/primary)
 "HJ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Engineering wing maintenance";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "HK" = (
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube"
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/structure/rack,
-/obj/item/powder_bag{
-	pixel_y = -10
-	},
-/obj/item/powder_bag{
-	pixel_y = -10
-	},
-/obj/item/powder_bag,
-/obj/item/powder_bag,
-/obj/item/powder_bag{
-	pixel_y = 8
-	},
-/obj/item/powder_bag{
-	pixel_y = 8
+/obj/machinery/conveyor_switch/oneway{
+	id = "atlas_gunpowder";
+	name = "Load gunpowder"
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
@@ -9586,23 +10083,18 @@
 	name = "Abandoned Bar"
 	})
 "HQ" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "HR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/ship/orange{
-	dir = 4
-	},
-/obj/machinery/deck_turret/powder_gate,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "HW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Ia" = (
@@ -9630,13 +10122,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "If" = (
+/obj/machinery/deck_turret/autoelevator,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/ship/orange,
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 8
 	},
-/obj/machinery/deck_turret/payload_gate,
 /turf/open/floor/plating,
 /area/nsv/weapons)
 "Ii" = (
@@ -9678,10 +10171,17 @@
 /area/maintenance/nsv/deck2/port)
 "Im" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/atmos)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "In" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/item/twohanded/required/kirbyplants{
@@ -9701,6 +10201,9 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"Iu" = (
+/turf/closed/wall/steel,
+/area/engine/break_room)
 "Iv" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
@@ -9725,11 +10228,16 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nsv/weapons)
 "IE" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/space/basic,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engine_room)
 "IG" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -9835,12 +10343,6 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Jh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance/six,
 /obj/structure/closet/crate,
@@ -9904,17 +10406,7 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "Jr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/ammo_sorter{
-	dir = 1;
-	id = "atlas1";
-	name = "Custom #2"
-	},
-/obj/item/ship_weapon/ammunition/torpedo,
-/obj/item/ship_weapon/ammunition/torpedo,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
@@ -9927,6 +10419,10 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/janitor)
+"Jv" = (
+/mob/living/simple_animal/pet/cat/original,
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/quartermaster/qm)
 "Jw" = (
 /obj/machinery/gauss_dispenser{
 	pixel_y = 26
@@ -10057,6 +10553,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
+"JQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/hallway/nsv/deck2/primary)
 "JS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -10065,12 +10568,15 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "JU" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
+/obj/machinery/deck_turret/payload_gate,
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/nsv/weapons)
 "JW" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/effect/turf_decal/ship/techfloor{
@@ -10142,12 +10648,18 @@
 	name = "Abandoned Bar"
 	})
 "Kf" = (
-/obj/structure/chair/office/light{
-	dir = 8;
-	name = "Storage Coordinator"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/dark,
-/area/nsv/weapons)
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/space/nearstation)
 "Kg" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/grille/broken,
@@ -10156,6 +10668,12 @@
 /area/crew_quarters/abandoned_gambling_den{
 	name = "Abandoned Bar"
 	})
+"Kh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "Ki" = (
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel/techmaint,
@@ -10199,6 +10717,7 @@
 /area/maintenance/nsv/deck2/port)
 "Kt" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/radiation,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -10228,9 +10747,14 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "KB" = (
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 1
+	},
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "KD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -10254,15 +10778,22 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "KF" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/engine/engine_room)
+"KG" = (
+/obj/machinery/air_sensor/atmos/oxygen_tank{
+	id_tag = "o2_sensor_alt"
+	},
+/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/light/small{
+	brightness = 3;
 	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
-/area/engine/atmos)
-"KG" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input,
-/obj/machinery/camera/autoname,
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "KH" = (
 /obj/structure/girder,
@@ -10402,13 +10933,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/engine/engine_room)
-"La" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "Lb" = (
 /obj/machinery/suit_storage_unit/pilot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -10433,14 +10957,21 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "Le" = (
-/obj/machinery/computer/atmos_control/tank/carbon_tank{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 1;
+	name = "Plasma to radiomix"
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 1;
+	name = "Plasma to constrictornator5000"
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -10550,6 +11081,10 @@
 /area/crew_quarters/abandoned_gambling_den{
 	name = "Abandoned Bar"
 	})
+"Lx" = (
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "Ly" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -10582,26 +11117,17 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nsv/weapons)
 "LD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 32
-	},
 /obj/effect/turf_decal/tile/ship/half/orange{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "LE" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	name = "Waste Tank Outlet"
 	},
-/obj/machinery/suit_storage_unit/atmos,
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "LF" = (
@@ -10616,9 +11142,8 @@
 /turf/open/floor/circuit/telecomms,
 /area/science)
 "LJ" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 4;
-	pixel_x = -32
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -10682,16 +11207,14 @@
 "Ma" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "Mc" = (
@@ -10715,14 +11238,10 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Me" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "atlas_standardshell";
-	name = "Load Standard Shells"
-	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/carpet/royalblack,
 /area/nsv/weapons)
 "Mf" = (
 /obj/structure/table,
@@ -10735,14 +11254,13 @@
 	name = "Abandoned Bar"
 	})
 "Mg" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/stormdrive_reactor{
-	reactor_id = "atlas_69420"
-	},
-/obj/effect/landmark/nuclear_waste_spawner/strong,
-/turf/open/floor/engine,
+/turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "Mh" = (
 /obj/structure/cable{
@@ -10761,10 +11279,11 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/hallway/nsv/deck2/primary)
 "Ml" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_room)
 "Mm" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -10803,17 +11322,27 @@
 /obj/item/ship_weapon/parts/missile/iff_card,
 /turf/open/floor/engine,
 /area/nsv/weapons)
+"Mr" = (
+/obj/structure/rack,
+/obj/item/toy/cards/deck/syndicate,
+/obj/item/toy/syndicateballoon,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "Ms" = (
 /obj/machinery/power/deck_relay,
 /obj/structure/cable,
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "Mt" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4;
-	icon_state = "pipe11-1"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -10829,10 +11358,14 @@
 	name = "Abandoned Bar"
 	})
 "Mv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/binary/stormdrive_reactor{
+	reactor_id = "atlas_69420"
+	},
+/obj/effect/landmark/nuclear_waste_spawner/strong,
+/turf/open/floor/engine,
 /area/engine/engine_room)
 "Mw" = (
 /obj/structure/ladder,
@@ -10841,6 +11374,16 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"Mx" = (
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 1;
+	name = "Co2 to MEGAmix"
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "My" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -10935,30 +11478,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"MR" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/blue{
-	dir = 1;
-	icon_state = "bordercorner"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/department/engine/atmos)
 "MV" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "MW" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
+	dir = 8;
+	piping_layer = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "MX" = (
@@ -11025,6 +11554,11 @@
 "Nh" = (
 /turf/open/space/basic,
 /area/space)
+"Nk" = (
+/obj/item/banner/medical,
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "Nl" = (
 /obj/structure/sign/ship/deck/two,
 /turf/closed/wall/r_wall,
@@ -11042,7 +11576,14 @@
 	name = "Abandoned Bar"
 	})
 "Nn" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Nr" = (
@@ -11093,6 +11634,19 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/nsv/deck2/primary)
+"NG" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "NH" = (
 /obj/structure/stairs{
 	dir = 8
@@ -11105,24 +11659,23 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/computer/rdconsole/production{
-	dir = 1
-	},
+/obj/machinery/vending/tool,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "NO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/ship/orange,
-/obj/machinery/deck_turret/powder_gate,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "NP" = (
 /obj/structure/disposalpipe/trunk/multiz,
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/area/engine/break_room)
 "NQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -11192,13 +11745,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "Ob" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/obj/machinery/light/small,
-/turf/open/floor/engine/co2,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
+	dir = 1
+	},
+/turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "Oc" = (
 /obj/structure/disposalpipe/segment{
@@ -11206,10 +11762,24 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/rack,
+/obj/item/wirecutters,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/nsv/deck2/starboard)
+"Od" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/heads/chief)
 "Oe" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -11248,19 +11818,16 @@
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/hanger/notkmcstupidhanger)
 "Oh" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
-"Oi" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
+"Oi" = (
+/obj/effect/landmark/start/master_at_arms,
+/turf/open/floor/carpet/royalblack,
+/area/nsv/weapons)
 "Oj" = (
 /obj/machinery/conveyor/slow{
 	dir = 8;
@@ -11377,7 +11944,10 @@
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
 "Oy" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+/obj/machinery/computer/atmos_control/tank/toxin_tank{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -11462,18 +12032,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "OJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "OK" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
 	},
-/obj/machinery/meter/atmos/atmos_waste_loop,
-/turf/open/floor/plating,
-/area/engine/atmos)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/primary)
 "OO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -11491,16 +12059,28 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
+"OS" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engine_room)
 "OV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/computer/ammo_sorter{
+	dir = 4;
+	id = "atlas1"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "OW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/ship/orange,
@@ -11520,18 +12100,18 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	dir = 1;
-	name = "Plasma to radiomix"
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 1;
-	name = "Plasma to constrictornator5000"
-	},
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"Pa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "Pc" = (
-/obj/effect/spawner/room/fivexfour,
+/obj/effect/spawner/room/threexthree,
 /turf/template_noop,
 /area/maintenance/nsv/deck2/port)
 "Pd" = (
@@ -11568,8 +12148,23 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/half/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"Pj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/heads/chief)
 "Pk" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "69"
@@ -11586,13 +12181,13 @@
 /turf/open/floor/monotile/dark,
 /area/maintenance/nsv/deck2/port)
 "Pl" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
-/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/machinery/vending/snack/random,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "Pp" = (
@@ -11610,39 +12205,46 @@
 /area/hallway/nsv/deck2/primary)
 "Pq" = (
 /obj/machinery/camera/autoname,
-/obj/structure/rack,
-/obj/item/powder_bag{
-	pixel_y = -10
-	},
-/obj/item/powder_bag{
-	pixel_y = -10
-	},
-/obj/item/powder_bag,
-/obj/item/powder_bag,
-/obj/item/powder_bag{
-	pixel_y = 8
-	},
-/obj/item/powder_bag{
-	pixel_y = 8
+/obj/machinery/computer/ammo_sorter{
+	id = "atlas2";
+	name = "Gunpowder Rack Control Console"
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Pr" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/ammo_sorter{
+	id = "atlas1";
+	name = "Custom #2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/item/ship_weapon/ammunition/torpedo,
+/obj/item/ship_weapon/ammunition/torpedo,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/monotile/steel,
+/area/nsv/weapons)
+"Ps" = (
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "garbage"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
-/area/nsv/weapons)
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "Pt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11652,6 +12254,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science)
+"Pv" = (
+/obj/item/storage/toolbox/brass/prefilled,
+/obj/item/stack/tile/brass{
+	amount = 50
+	},
+/turf/open/floor/bronze,
+/area/maintenance/nsv/deck2/starboard)
 "Px" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -11662,6 +12271,20 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"Py" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
+"Pz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/lattice/catwalk/over/ship{
+	color = "#868B9C"
+	},
+/turf/open/floor/plating,
+/area/engine/break_room)
 "PA" = (
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 1
@@ -11772,15 +12395,14 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "PV" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "atlas_standardshell"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/conveyor{
+	id = "atlas_naval"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "PX" = (
 /obj/structure/lattice/catwalk/over/ship,
@@ -11792,14 +12414,20 @@
 /area/nsv/weapons)
 "Qc" = (
 /obj/machinery/conveyor{
-	dir = 10;
-	id = "garbage"
+	dir = 6;
+	id = "cmbelt"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 2
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -11840,6 +12468,10 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/chapel/main)
+"Qj" = (
+/obj/structure/closet/crate/secure/loot,
+/turf/open/floor/bronze,
+/area/maintenance/nsv/deck2/starboard)
 "Qk" = (
 /obj/effect/turf_decal/tile/ship/half/orange{
 	dir = 4
@@ -11870,6 +12502,11 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
+"Qr" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "Qs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -11912,26 +12549,19 @@
 /turf/open/floor/carpet/red,
 /area/security/brig)
 "Qx" = (
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/obj/machinery/atmospherics/miner/n2o,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 1
+/obj/structure/chair/office/light{
+	dir = 8;
+	name = "Storage Coordinator"
 	},
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
-"Qy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/carpet/ship,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"Qy" = (
+/obj/machinery/computer/bounty{
+	dir = 4;
+	layer = 2.88
+	},
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/quartermaster/qm)
 "Qz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11945,11 +12575,16 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "QB" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
-	dir = 4;
-	id = "sdmix_in"
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 4
 	},
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/machinery/atmospherics/components/binary/magnetic_constrictor{
+	dir = 8;
+	piping_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "QC" = (
 /obj/structure/cable{
@@ -12009,14 +12644,12 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "QL" = (
-/obj/machinery/light/small,
-/obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/ship/blue,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "QN" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12025,14 +12658,8 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "QO" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 5;
-	icon_state = "pipe11-1"
-	},
-/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer3{
+/obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -12110,8 +12737,8 @@
 	brightness = 3;
 	dir = 1
 	},
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/chair/office/light{
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/quartermaster/qm)
@@ -12146,13 +12773,16 @@
 /turf/open/floor/plasteel/techmaint,
 /area/science)
 "Ri" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/ship/techfloor{
+	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 4
 	},
-/area/maintenance/nsv/deck2/port)
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck2/primary)
 "Rj" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -12166,21 +12796,10 @@
 /turf/open/floor/monotile/dark,
 /area/science)
 "Rk" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3,
-/obj/machinery/computer/atmos_control/tank/air_tank{
-	density = 0;
-	dir = 4;
-	input_tag = "sdmix_in";
-	name = "Reactor Mix Control";
-	output_tag = "sdmix_out";
-	pixel_x = -9;
-	sensors = list("sdmix_sensor" = "Reactor Mix Tank")
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
+/obj/structure/lattice/catwalk/over/ship,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/monotile/steel,
+/area/nsv/weapons)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -12235,18 +12854,12 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "Rs" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 8
+/obj/structure/lattice/catwalk/over/ship,
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"Ru" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
+/turf/open/floor/monotile/steel,
+/area/nsv/weapons)
 "Rw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -12291,6 +12904,14 @@
 	dir = 1
 	},
 /area/chapel/main)
+"RB" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "RF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12327,12 +12948,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
-"RK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/ship/half/yellow,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
 "RL" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer1{
 	dir = 9
@@ -12346,13 +12961,16 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "RP" = (
-/obj/machinery/computer/ship/fighter_controller,
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 1
 	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons)
+/obj/item/bedsheet/qm,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/quartermaster/qm)
 "RQ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/red,
@@ -12456,16 +13074,15 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "Se" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	name = "Waste Tank Outlet"
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/portable_atmospherics/scrubber/huge/movable,
-/turf/open/floor/plating,
-/area/engine/atmos)
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "Sf" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "Sh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -12555,6 +13172,23 @@
 /obj/effect/turf_decal/tile/ship/half/yellow,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"St" = (
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/station/mining{
+	name = "Quartermaster's Office";
+	req_one_access_txt = "41"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/quartermaster/qm)
+"Sv" = (
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "Sz" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -12577,9 +13211,16 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "SC" = (
-/obj/item/trash/raisins,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 5;
+	icon_state = "pipe11-1"
+	},
+/obj/structure/extinguisher_cabinet/west,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 6
+	},
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/area/engine/atmos)
 "SF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12592,9 +13233,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "SH" = (
-/obj/machinery/computer/ship/ordnance,
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons)
+/obj/structure/closet/secure_closet/quartermaster,
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/quartermaster/qm)
 "SI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12614,7 +13255,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "SK" = (
-/turf/open/floor/engine/vacuum,
+/turf/closed/wall/r_wall{
+	layer = 2.91
+	},
 /area/engine/atmos)
 "SM" = (
 /obj/structure/cable{
@@ -12629,6 +13272,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/steel,
 /area/science)
+"SQ" = (
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/item/powder_bag,
+/obj/machinery/conveyor/inverted{
+	dir = 5;
+	id = "atlas_gunpowder"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "SS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12709,11 +13365,10 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "Tf" = (
-/obj/machinery/computer/ammo_sorter{
-	dir = 4;
-	id = "atlas1"
-	},
-/turf/open/floor/monotile/dark,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/paper_bin/construction,
+/obj/item/pen/fountain,
+/turf/open/floor/carpet/royalblack,
 /area/nsv/weapons)
 "Tg" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -12787,17 +13442,11 @@
 /turf/open/floor/carpet/red,
 /area/security/brig)
 "Tt" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess{
-	name = "EVA";
-	req_one_access_txt = "18"
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/start/chief_engineer,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/chief)
 "Tu" = (
 /obj/structure/table,
 /obj/machinery/camera/autoname{
@@ -12836,17 +13485,9 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "Ty" = (
-/obj/item/ship_weapon/ammunition/torpedo/nuke/antonio{
-	name = "Giorno"
-	},
-/obj/structure/bed/dogbed{
-	name = "Antonio's Bed"
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/carpet/ship,
-/area/nsv/weapons)
+/obj/effect/landmark/start/quartermaster,
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/quartermaster/qm)
 "Tz" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /obj/structure/cable{
@@ -12970,8 +13611,12 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "TX" = (
+/obj/machinery/computer/deckgun,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 1
@@ -13005,14 +13650,12 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/engine/engine_room)
 "Ub" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 9;
-	icon_state = "pipe11-1"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Uc" = (
@@ -13107,6 +13750,16 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"Uw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 8
+	},
+/obj/machinery/deck_turret/payload_gate,
+/turf/open/floor/plating,
+/area/nsv/weapons)
 "Uz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13128,10 +13781,12 @@
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/hanger/notkmcstupidhanger)
 "UC" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/area/maintenance/nsv/deck2/starboard)
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "UE" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable/yellow{
@@ -13153,25 +13808,25 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/ship/engineering/glass{
-	name = "Engineering";
-	req_access_txt = "24;10"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 4;
+	id = "reactorld19";
+	name = "Reactor Room shutter"
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
@@ -13204,6 +13859,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "UM" = (
@@ -13218,12 +13876,10 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss/battery/deck2/port)
 "UQ" = (
-/obj/machinery/computer/atmos_control/tank/toxin_tank{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+	dir = 10
 	},
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "UR" = (
@@ -13246,11 +13902,15 @@
 	},
 /area/maintenance/department/science)
 "UZ" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 9;
+	icon_state = "pipe11-1"
 	},
-/turf/open/floor/engine/co2,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "Va" = (
 /obj/structure/cable/yellow{
@@ -13299,10 +13959,16 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "Vi" = (
-/obj/effect/turf_decal/tile/ship/half/yellow{
+/obj/effect/turf_decal/tile/ship/yellow{
 	dir = 1
 	},
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/obj/machinery/vending/engineering,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "Vj" = (
@@ -13349,17 +14015,25 @@
 	name = "Abandoned Bar"
 	})
 "Vn" = (
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
-/area/maintenance/nsv/deck2/starboard)
+/area/engine/break_room)
 "Vp" = (
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/quartermaster/qm)
+"Vq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "Vr" = (
 /obj/structure/stairs{
 	dir = 8
@@ -13378,6 +14052,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/light_switch/west,
 /turf/open/floor/carpet/ship,
+/area/nsv/weapons)
+"Vu" = (
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Vv" = (
 /obj/structure/sign/ship/securearea{
@@ -13399,14 +14077,18 @@
 	})
 "Vz" = (
 /obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad"
+	dir = 4;
+	id = "garbage"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "Disposals"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 2
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -13434,23 +14116,24 @@
 /area/nsv/weapons)
 "VF" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "VG" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+/obj/item/beacon,
+/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer3{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/magnetic_constrictor{
-	dir = 8;
-	piping_layer = 1
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -13481,6 +14164,10 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"VK" = (
+/obj/effect/landmark/start/depsec/engineering,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "VM" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -13519,9 +14206,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "VT" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/grille/wall,
-/turf/open/space/basic,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
 /area/engine/engine_room)
 "VU" = (
 /obj/machinery/light_switch/west,
@@ -13530,10 +14218,20 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "VY" = (
-/obj/machinery/door/poddoor{
-	id = "dispo";
-	name = "Disposal Shutter"
+/obj/machinery/mass_driver{
+	id = "dispo"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "VZ" = (
@@ -13576,21 +14274,23 @@
 "Wd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/airlock/ship/engineering/glass{
-	name = "Atmospherics";
-	req_one_access_txt = "24;10"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	sortType = 32
+	},
 /turf/open/floor/monotile/steel,
-/area/engine/atmos)
+/area/hallway/nsv/deck2/primary)
 "We" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -13601,11 +14301,15 @@
 /turf/open/floor/engine,
 /area/nsv/weapons)
 "Wf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 5;
+	icon_state = "pipe11-1"
 	},
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "Wk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/camera/autoname,
@@ -13644,6 +14348,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/monotile/steel,
 /area/science)
+"Wq" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "Wr" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
@@ -13658,12 +14366,22 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "Wu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
+"Wv" = (
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Engineering wing maintenance";
+	req_one_access_txt = "10;24"
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
@@ -13678,13 +14396,13 @@
 	dir = 10;
 	icon_state = "pipe"
 	},
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 1
+	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
 "Wy" = (
@@ -13719,22 +14437,40 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"WF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "WH" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 1
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
-"WJ" = (
+"WI" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/conveyor_switch/oneway{
+	id = "atlas_naval";
+	name = "Conveyor toggle"
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/engine,
-/area/engine/engine_room)
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
+"WJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9;
+	icon_state = "pipe11-1"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "WM" = (
 /obj/machinery/aug_manipulator,
 /turf/open/floor/plasteel/techmaint,
@@ -13757,40 +14493,55 @@
 /turf/open/floor/monotile/dark,
 /area/security/brig)
 "WT" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "atlas_naval"
+/obj/machinery/computer/ship/fighter_controller,
+/obj/machinery/button/door{
+	id = "gaussgang_atlas";
+	name = "public gauss access";
+	pixel_y = 32;
+	req_one_access_txt = "69"
+	},
+/obj/machinery/button/door{
+	id = "muni_atlas";
+	name = "public munitions access";
+	pixel_y = 24;
+	req_one_access_txt = "69"
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "WW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/over/ship,
-/turf/open/floor/monotile/steel,
+/obj/machinery/ammo_sorter{
+	dir = 4;
+	id = "atlas1";
+	name = "Standard Shells #2"
+	},
+/obj/item/ship_weapon/ammunition/naval_artillery,
+/obj/item/ship_weapon/ammunition/naval_artillery,
+/obj/item/ship_weapon/ammunition/naval_artillery,
+/turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "WX" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/engine/atmos)
-"WY" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/ship/orange{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/orange,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
+"WY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/primary)
@@ -13830,12 +14581,17 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"Xf" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/obj/item/extinguisher/mini,
+/turf/open/floor/monotile/steel,
+/area/engine/break_room)
 "Xg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer3{
-	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -13871,17 +14627,12 @@
 /area/quartermaster/storage)
 "Xu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/airlock/ship/engineering/glass{
-	name = "Atmospherics";
-	req_one_access_txt = "24;10"
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
+/obj/effect/turf_decal/tile/ship/orange,
 /turf/open/floor/monotile/steel,
-/area/engine/atmos)
+/area/hallway/nsv/deck2/primary)
 "Xx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13975,21 +14726,30 @@
 /turf/open/floor/engine,
 /area/quartermaster/storage)
 "XL" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/wrench/brass,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/chief)
+"XM" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/relic,
+/obj/item/toy/figure/syndie,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/area/maintenance/nsv/deck2/port)
 "XP" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/ammo_sorter{
-	dir = 1;
-	id = "atlas1";
-	name = "Custom #1"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/ship_weapon/ammunition/torpedo/nuke,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Master At Arms' Desk";
+	departmentType = 5;
+	name = "Master at Arms RC";
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "XU" = (
@@ -14005,13 +14765,21 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss/battery/deck2/starboard)
 "XV" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "atlas_specialshells";
-	name = "Load AP shells"
+/obj/structure/window/reinforced,
+/obj/machinery/ammo_sorter{
+	dir = 4;
+	id = "atlas1";
+	name = "AP shells"
 	},
+/obj/item/ship_weapon/ammunition/naval_artillery/ap,
+/obj/item/ship_weapon/ammunition/naval_artillery/ap,
+/obj/item/ship_weapon/ammunition/naval_artillery/ap,
+/obj/item/ship_weapon/ammunition/naval_artillery/ap,
+/obj/item/ship_weapon/ammunition/naval_artillery/ap,
+/obj/item/ship_weapon/ammunition/naval_artillery/ap,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "XW" = (
@@ -14094,13 +14862,9 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "Yh" = (
-/obj/structure/grille,
-/obj/effect/turf_decal/tile/ship/blue{
-	dir = 1;
-	icon_state = "bordercorner"
-	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "Yi" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -14122,10 +14886,6 @@
 /turf/open/floor/engine,
 /area/quartermaster/storage)
 "Ym" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Yn" = (
@@ -14157,17 +14917,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer1{
-	name = "Nitrogen to Air Mix";
-	target_pressure = 2000
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer3{
-	name = "Nitrogen to mix"
-	},
+/obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
 	dir = 4;
 	icon_state = "pipe11-1"
 	},
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Yt" = (
@@ -14205,6 +14960,16 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/engine,
 /area/quartermaster/storage)
+"YE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/rack,
+/obj/item/relic,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "YF" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
@@ -14282,16 +15047,23 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "YT" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "YU" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/over/ship,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/ammo_sorter{
+	id = "atlas1";
+	name = "Custom #1"
+	},
+/obj/item/ship_weapon/ammunition/torpedo/nuke,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
@@ -14392,16 +15164,16 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/nsv/deck2/primary)
 "Zm" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 8;
-	icon_state = "borderhalf"
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/ship/techfloor{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
+/area/crew_quarters/heads/chief)
 "Zn" = (
 /obj/structure/closet/crate{
 	opened = 1
@@ -14420,6 +15192,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "Zr" = (
@@ -14434,15 +15209,24 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "Zu" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "atlas_specialshells"
 	},
-/obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
+/obj/machinery/conveyor{
+	id = "atlas_naval"
 	},
 /turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck2/primary)
+/area/nsv/weapons)
+"Zv" = (
+/obj/machinery/computer/rdconsole/production{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/break_room)
 "Zw" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/structure/disposalpipe/segment{
@@ -14481,15 +15265,19 @@
 /turf/open/floor/plating,
 /area/science)
 "ZF" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "atlas_specialshells";
+	name = "Load AP shells"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "ZH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "ZI" = (
@@ -38884,9 +39672,9 @@ an
 vD
 FQ
 PP
-FQ
-PP
-FQ
+TF
+Kf
+TF
 ue
 FQ
 le
@@ -39139,13 +39927,13 @@ an
 an
 an
 vD
-FQ
-PP
-TF
-PP
-TF
-ue
-FQ
+Gi
+MO
+MO
+MO
+MO
+MO
+yT
 le
 FQ
 ue
@@ -39397,11 +40185,11 @@ kD
 kD
 vD
 Gi
-kD
-kD
-kD
-kD
-kD
+MO
+zo
+KF
+zo
+MO
 lO
 le
 TF
@@ -39656,7 +40444,7 @@ MO
 GT
 MO
 MO
-MO
+Ml
 MO
 MO
 kD
@@ -39914,7 +40702,7 @@ Hg
 MO
 VT
 IE
-VT
+Se
 MO
 MO
 MO
@@ -40169,9 +40957,9 @@ mX
 Gk
 Ib
 MO
-MO
+Am
 Mv
-MO
+Sf
 MO
 jV
 Dq
@@ -40179,7 +40967,7 @@ fp
 MO
 kD
 an
-Nh
+an
 an
 an
 an
@@ -40429,15 +41217,15 @@ rj
 mS
 VF
 bC
-rj
+MO
 PD
 QK
 uz
 MO
 kD
-an
-Nh
-an
+kD
+kD
+kD
 hg
 hg
 hg
@@ -40682,27 +41470,27 @@ gf
 rc
 wL
 LR
-rj
-Wf
+MO
+oz
 Mg
-vW
-rj
-PD
-QK
+oz
+MO
+io
+OS
 ry
 MO
-kD
-an
-Nh
-an
-mL
-mL
-mL
-mL
-mL
-mL
-mL
-mL
+MO
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
 an
 Nh
 Nh
@@ -40925,7 +41713,7 @@ kH
 kH
 kH
 kH
-oD
+bh
 oD
 oD
 Pc
@@ -40940,26 +41728,26 @@ Un
 zZ
 Nu
 MO
-WJ
+rj
 Ax
-wa
+rj
 MO
 Qf
 go
 MO
 MO
 MO
-an
-an
-an
-mL
-mL
+kw
+Zv
+Vq
+EN
+wz
 aV
-aV
-aV
+eG
+dr
 sU
-mL
-mL
+wz
+wz
 an
 Nh
 Nh
@@ -41181,8 +41969,8 @@ an
 kH
 jc
 Uv
-kH
-oD
+aq
+bh
 oD
 oD
 oD
@@ -41206,17 +41994,17 @@ bG
 nh
 Ua
 MO
-mL
-mL
-mL
-mL
-mL
-aV
-aV
-aV
-aV
-mL
-mL
+aZ
+aZ
+WF
+qa
+DB
+Pz
+Pa
+mn
+EH
+wz
+wz
 an
 Nh
 Nh
@@ -41463,17 +42251,17 @@ lo
 MO
 MO
 MO
-mL
-mL
-mL
-mL
-mL
-aV
-aV
-aV
-aV
-mL
-mL
+VK
+Py
+rt
+CX
+wz
+yJ
+fT
+RB
+DH
+wz
+wz
 an
 Nh
 Nh
@@ -41695,12 +42483,12 @@ an
 kH
 Kp
 cM
-Oi
-oD
-oD
-oD
-oD
-iW
+kH
+kH
+kH
+gm
+kH
+kH
 Yr
 Gf
 jo
@@ -41716,19 +42504,19 @@ nA
 BJ
 my
 Ld
-im
+Ld
 Gl
 gh
 pg
 qa
 Vn
 UC
-Ie
-sj
-aV
-aV
-aV
-aV
+DK
+wz
+wz
+mL
+mL
+mL
 mL
 mL
 an
@@ -41953,15 +42741,15 @@ kH
 kH
 kH
 kH
-oD
-oD
-oD
-oD
 kH
-bh
+bs
+dl
+dl
+dl
+dl
 AU
-jN
-jN
+kN
+bh
 Jo
 oF
 cB
@@ -41974,18 +42762,18 @@ ul
 mp
 Um
 Vi
-oF
+hR
 NP
 DG
-ho
 ld
+Bu
 sP
-UC
+Xf
+cd
+zS
 mL
-aV
-aV
-aV
-aV
+Pv
+Qj
 mL
 mL
 an
@@ -42211,10 +42999,10 @@ CE
 CE
 CE
 CE
-kH
-zo
-kH
-kH
+iC
+bh
+bh
+ic
 nD
 Jh
 wd
@@ -42231,21 +43019,21 @@ ul
 By
 RJ
 NI
-oF
-qI
+Iu
+Iu
 pk
-qI
-qI
+vS
+by
 HQ
-UC
+ww
+de
+Sv
 mL
 mL
-mR
 mL
 mL
 mL
 mL
-an
 Nh
 Nh
 Nh
@@ -42468,11 +43256,11 @@ CE
 ET
 Zx
 CE
-nu
-bh
-Sf
-kH
-SC
+iC
+wd
+wd
+wd
+wd
 aI
 qI
 rR
@@ -42491,18 +43279,18 @@ cD
 oF
 qI
 xA
-Zu
+qI
 qI
 Oh
-Ie
+mx
 Gp
-Ie
-Ie
+mL
+mL
 qd
 nL
 fe
 VY
-an
+Ew
 ms
 jy
 jy
@@ -42726,9 +43514,9 @@ FX
 Tc
 CE
 Al
-bs
-dl
-dl
+wd
+hH
+jP
 Ri
 iD
 nq
@@ -42739,7 +43527,7 @@ eL
 lK
 mH
 oh
-oz
+Bx
 UL
 ey
 GG
@@ -42751,15 +43539,15 @@ qG
 Pl
 qI
 dx
-Ie
-ob
-vX
-Ie
-Ie
-yr
-Vz
+gM
+wP
 mL
-an
+Lx
+Ie
+Ie
+Vz
+tC
+mL
 Nh
 ms
 Nh
@@ -42982,12 +43770,12 @@ CE
 CE
 CE
 CE
-Ml
-vi
+iC
 wd
-qI
-qI
-qI
+Jk
+Jk
+Jk
+Jk
 vs
 sG
 dQ
@@ -42996,9 +43784,9 @@ oF
 oF
 IV
 oF
-Un
+oF
 UG
-mU
+oF
 oF
 IV
 oF
@@ -43006,17 +43794,17 @@ Tl
 Vr
 Mh
 NZ
-qI
-qI
-qI
-qI
-qI
-kC
-ca
-vJ
-Vz
+Eg
+Eg
+Eg
+Eg
+Eg
+Eg
+Eg
+Ie
+oL
+tC
 mL
-an
 an
 an
 an
@@ -43239,12 +44027,12 @@ kH
 GA
 Ol
 kH
-bh
-vi
+iC
 wd
+iA
 pZ
 pT
-aP
+Jk
 ew
 nS
 Pd
@@ -43263,17 +44051,17 @@ uk
 rS
 Je
 ao
-qI
+CQ
 rr
 rJ
-qU
-qI
+Eg
+mw
 tJ
-sP
+Eg
 zq
 Qc
+Ps
 mL
-an
 an
 an
 an
@@ -43496,9 +44284,9 @@ kH
 GO
 Yr
 sl
-bh
 iC
-aq
+gA
+Jk
 Jk
 Jk
 Jk
@@ -43521,16 +44309,16 @@ vd
 pl
 Pi
 qN
-Jk
-Jk
-Jk
+Pj
+Od
+bg
 Tt
-Ie
-sP
+jB
+qk
+fs
 mL
-vw
+BK
 mL
-an
 Ng
 Ng
 Ng
@@ -43753,9 +44541,9 @@ kH
 xg
 HG
 kH
-kH
-bt
+aP
 WB
+iW
 ay
 hM
 aY
@@ -43777,17 +44565,17 @@ YZ
 bD
 un
 XE
-qI
+EO
 Zm
 oB
-dp
-qI
+Eg
+uQ
 XL
-Ie
+Eg
 LJ
 bq
+YE
 mL
-kD
 XG
 ns
 ns
@@ -44010,8 +44798,8 @@ kH
 xM
 Kt
 kH
-DD
-iC
+bu
+wd
 wd
 wd
 qI
@@ -44023,28 +44811,28 @@ pc
 zI
 zI
 zI
-zI
-zI
+RN
+RN
 HJ
-zI
-zI
+RN
+RN
 zI
 zI
 zI
 Qv
 kq
 pc
-qI
-qI
 Eg
-qI
-qI
-qI
-qI
-Ie
+Eg
+Eg
+Eg
+Eg
+Eg
+Eg
+wY
 Oc
 mL
-kD
+mL
 TL
 TL
 TL
@@ -44275,19 +45063,19 @@ So
 oQ
 qI
 rf
-un
-Ef
-zI
-zI
+kQ
+lt
+mf
+mU
 mJ
-ru
-oW
+RN
+wC
 nH
-lm
-Am
+wC
+RN
 lh
-zI
-zI
+Hz
+Wv
 zf
 dE
 bB
@@ -44301,7 +45089,7 @@ qI
 Ie
 nI
 mL
-kD
+mL
 iX
 iX
 iX
@@ -44537,11 +45325,11 @@ Ef
 zI
 lW
 bx
-xI
-pt
+RN
+wC
 ac
 wC
-wC
+RN
 eD
 dW
 zI
@@ -44558,7 +45346,7 @@ ks
 gl
 nI
 mL
-kD
+mL
 Va
 Va
 Va
@@ -44795,14 +45583,14 @@ zI
 lY
 ZR
 RN
-RN
+Dd
 je
-RN
+wC
 RN
 gd
 Wu
 zI
-FI
+Es
 zQ
 ux
 xt
@@ -44815,7 +45603,7 @@ qI
 Ie
 Uz
 mL
-kD
+mL
 XG
 ns
 ns
@@ -45046,21 +45834,21 @@ Jf
 Mw
 qI
 Kk
-ky
-kO
-lw
-mf
-QL
+un
+Ef
+RN
+RN
+RN
 RN
 SK
 ro
-SK
 RN
-gm
-oG
-yU
-WY
-lx
+RN
+RN
+RN
+RN
+Jz
+un
 Dv
 ew
 Nr
@@ -45296,7 +46084,7 @@ JY
 kH
 kH
 bh
-iC
+hc
 wd
 wd
 wd
@@ -45305,16 +46093,16 @@ jE
 rf
 un
 aM
-zI
-bO
-hv
 RN
-SK
+bO
+YT
+vJ
+Di
 cf
-SK
-RN
-MR
-bO
+SC
+Mx
+YT
+lE
 iY
 Jz
 un
@@ -45562,17 +46350,17 @@ wd
 QG
 lx
 TU
-zI
-KB
-hv
 RN
+KB
+Yh
+vW
 qw
 QB
-SK
-RN
+UZ
+hT
 Yh
-KB
-zI
+qS
+RN
 Bw
 un
 ql
@@ -45820,15 +46608,15 @@ rf
 un
 BP
 RN
-RN
-RN
-RN
+mZ
+ru
+vX
 BU
 Cv
-RN
-RN
-RN
-RN
+Wf
+Cg
+ru
+wZ
 Nl
 Jz
 un
@@ -46064,7 +46852,7 @@ gU
 Vh
 kH
 bu
-bh
+sk
 dC
 ha
 Rb
@@ -46077,15 +46865,15 @@ jY
 VJ
 ny
 RN
-rh
-pH
+RN
+RN
 gn
-Rk
+ZB
 aT
 AL
 BG
-pH
-UZ
+RN
+RN
 RN
 oY
 pn
@@ -46592,13 +47380,13 @@ wv
 Ef
 RN
 KG
-jh
+Yh
 tg
-JU
+ZB
 QO
 or
 Oy
-jh
+Yh
 BR
 RN
 Jz
@@ -46848,15 +47636,15 @@ Oe
 wv
 Ef
 RN
-RN
-RN
+nj
+ru
 ev
 ZB
 VG
 Mt
 xq
-RN
-RN
+ru
+DQ
 RN
 Jz
 un
@@ -47105,15 +47893,15 @@ ef
 wv
 Ef
 RN
-ZF
-pH
+RN
+RN
 Ys
-oc
+ZB
 eX
-uJ
+Xg
 OY
-pH
-jP
+RN
+RN
 RN
 Jz
 un
@@ -47365,7 +48153,7 @@ RN
 gu
 YT
 BC
-ZB
+DD
 iu
 rx
 UQ
@@ -47620,16 +48408,16 @@ wv
 Ef
 RN
 jI
-jh
+Yh
 Fg
-ZB
+FA
 eF
 Xg
 GB
-jh
-lD
+Yh
+wC
 RN
-Jz
+NG
 un
 ql
 yX
@@ -47876,15 +48664,15 @@ kc
 Pf
 Ef
 RN
-RN
-RN
+nu
+ru
 cs
-ZB
+Gu
 OJ
 HW
 LE
-RN
-RN
+YT
+fi
 nk
 Jz
 un
@@ -48133,15 +48921,15 @@ zX
 tk
 Ef
 RN
-xd
-pH
+RN
+RN
 ad
 mY
-nM
-FB
 Ym
-pH
-KF
+Xg
+Ym
+RN
+RN
 RN
 HN
 wq
@@ -48371,7 +49159,7 @@ kH
 ic
 eR
 bh
-wl
+Fp
 wl
 wl
 wl
@@ -48389,17 +49177,17 @@ YQ
 Wk
 SF
 Yv
+mR
 RN
-Qx
-YT
+RN
 mV
 Nn
 nT
-HW
+WJ
 vH
-YT
-SK
 RN
+tc
+FK
 sR
 un
 Ef
@@ -48646,17 +49434,17 @@ YS
 uP
 tk
 Ss
+mR
 RN
-Dd
-jh
-Rs
-mZ
+RN
+RN
+RN
 nZ
-hH
-Se
+RN
+RN
 pH
 EB
-RN
+ck
 LA
 un
 ny
@@ -48665,8 +49453,8 @@ IW
 IW
 IW
 IW
-ew
-ew
+JQ
+BE
 Rm
 qI
 zA
@@ -48882,7 +49670,7 @@ Nh
 Nh
 bf
 kD
-bh
+fO
 bh
 wl
 fG
@@ -48903,16 +49691,16 @@ ts
 JX
 kA
 hr
-RN
-RN
-RN
+fS
+nF
+fS
 OK
 Im
 mj
-HW
-mj
-RN
-RN
+WY
+fS
+fS
+fS
 fS
 dS
 pw
@@ -49138,8 +49926,8 @@ Nh
 Nh
 Nh
 bf
-kD
-bh
+Gz
+XM
 bh
 wl
 kB
@@ -49159,11 +49947,11 @@ gI
 WN
 XW
 bW
-Vc
-RK
+lw
 Xu
-La
-Ru
+Xu
+Xu
+Xu
 mr
 WX
 lX
@@ -49176,7 +49964,7 @@ yD
 BW
 Sh
 TK
-OV
+TK
 TK
 TK
 lN
@@ -49396,7 +50184,7 @@ Nh
 Nh
 bf
 kD
-bh
+Mr
 bh
 wl
 kM
@@ -49418,15 +50206,15 @@ GZ
 QP
 ht
 eY
+oc
+ew
 eY
 eY
 eY
 eY
 eY
-eY
-eY
-eY
-eY
+nd
+Dj
 eY
 Ww
 tr
@@ -49675,24 +50463,24 @@ eY
 ZS
 XB
 eY
-eY
-eY
+Jk
+nc
 eY
 pU
 ri
-Di
 eY
-eY
-eY
+ED
+Fa
+EJ
 eY
 eY
 pC
 zO
 eY
-rq
-gA
-rq
-eY
+Dy
+Dy
+Dy
+Dy
 pc
 vh
 pc
@@ -49910,9 +50698,9 @@ Nh
 Nh
 bf
 kD
-bh
-bh
-bh
+Nk
+lJ
+eI
 wl
 wl
 wl
@@ -49932,20 +50720,20 @@ Wy
 kE
 Te
 eY
+oG
+nc
 eY
-eY
-nF
 BI
-BI
+Oi
 xk
-Gu
-eY
-eY
+mP
+Kh
+dB
 eY
 pP
 dH
 qt
-rq
+eY
 SH
 Qy
 sa
@@ -50167,8 +50955,8 @@ Nh
 Nh
 bf
 kD
-bh
-bh
+pM
+Hm
 bh
 kH
 WN
@@ -50189,24 +50977,24 @@ kh
 kE
 Te
 eY
-eY
+rh
 nc
-hc
+eY
 Me
 Tf
-XV
+eY
 WT
 XP
-eY
+fm
 oO
 oZ
 dH
 qt
-rq
-RP
-GM
-FE
 eY
+RP
+Jv
+FE
+Dy
 Jz
 un
 GP
@@ -50424,9 +51212,9 @@ Nh
 Nh
 bf
 kD
+Wq
 bh
-bh
-bh
+Qr
 kH
 WN
 GC
@@ -50447,23 +51235,23 @@ zh
 XB
 eY
 eY
-vF
-hc
-nj
-Kf
-kN
-WT
-Jr
+eY
+eY
+eY
+eY
+eY
+eY
+eY
 eY
 eY
 eY
 pE
 zO
 eY
-eY
+Dy
 pd
 Ty
-eY
+Dy
 oV
 un
 GP
@@ -50704,13 +51492,13 @@ kE
 Te
 Dt
 Cl
-Te
-Te
-Te
-WW
-Te
+eY
+eY
 GK
-Te
+WW
+XV
+eY
+eY
 YU
 Dl
 VU
@@ -50719,7 +51507,7 @@ vu
 Eu
 Dy
 Dy
-Dy
+St
 Dy
 XY
 un
@@ -50961,13 +51749,13 @@ kF
 kP
 kP
 bc
-kP
-kP
-kP
+eY
+wa
 PV
-kP
+PV
+Zu
 rl
-kP
+eY
 Pr
 kP
 kP
@@ -50976,7 +51764,7 @@ Te
 XF
 Dy
 tB
-Bx
+Vp
 Bs
 FI
 Sb
@@ -51218,13 +52006,13 @@ mP
 mP
 CA
 DV
-mP
-mP
-mP
-Te
-mP
+vi
+xd
+GM
+OV
+ZF
 DT
-mP
+WI
 fa
 uZ
 mP
@@ -51475,13 +52263,13 @@ eY
 eY
 QU
 mz
+vw
 mP
+Jr
+Qx
+Vu
 mP
-mP
-Te
-mP
-mP
-mP
+fA
 gc
 mk
 mP
@@ -51731,14 +52519,14 @@ PF
 hi
 eY
 Zn
-Dk
+rq
 NO
-hI
 HR
-Te
-NO
-hI
 HR
+QL
+mk
+mP
+vK
 nw
 mP
 mP
@@ -51989,13 +52777,13 @@ MK
 Gx
 ly
 mD
-dK
+qQ
 CG
 uY
 Te
 qQ
 CG
-tn
+uY
 nw
 Te
 Te
@@ -52247,7 +53035,7 @@ eY
 MG
 dH
 fx
-ig
+rX
 uG
 Te
 If
@@ -52503,13 +53291,13 @@ xL
 eY
 Gt
 dH
-mP
-mP
-mP
-FA
-mP
-mP
-mP
+vF
+xI
+JU
+Te
+Uw
+zN
+CB
 tZ
 xN
 Mi
@@ -52761,14 +53549,14 @@ eY
 HK
 dH
 mP
-kQ
-kQ
-Te
-kQ
-kQ
+mP
+mP
+Rk
+mP
+mP
 mP
 ct
-mP
+we
 Mi
 tp
 tp
@@ -53018,11 +53806,11 @@ eY
 lf
 dH
 mP
-qq
-qq
+yr
+yr
 Te
-qq
-qq
+yr
+yr
 mP
 ct
 Md
@@ -53265,14 +54053,14 @@ iV
 fr
 pS
 As
-Ly
+ky
 eY
 oE
 fj
 Ql
 zU
 eY
-lf
+uh
 dH
 mP
 qq
@@ -53532,11 +54320,11 @@ eY
 Pq
 JN
 JC
-iA
-iA
-Te
-iA
-iA
+qq
+qq
+Rs
+qq
+qq
 mP
 ct
 tX
@@ -53786,14 +54574,14 @@ gD
 RQ
 VE
 eY
-lf
+SQ
 Dk
 Xe
-Te
-Te
+yU
+yU
 jX
-Te
-Te
+yU
+yU
 mP
 ct
 mP
@@ -54040,16 +54828,16 @@ lz
 eY
 kd
 gD
-RQ
+kO
 Cn
 eY
-lf
+Bk
 Dk
 Te
 vM
 ea
-lt
-gD
+mP
+mP
 JP
 Te
 ct

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -21,18 +21,10 @@
 /turf/open/floor/plasteel/grid/techfloor,
 /area/ai_monitored/turret_protected/ai)
 "ad" = (
-/obj/machinery/sleeper{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grid/lino,
-/area/medical/medbay)
-"ae" = (
-/obj/effect/turf_decal/tile/ship/green,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
+/obj/structure/lattice/catwalk/over/ship,
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "af" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Smoking area"
@@ -50,10 +42,10 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "ag" = (
-/obj/structure/curtain,
 /obj/machinery/shower{
-	dir = 8
+	pixel_y = 20
 	},
+/obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/dorms)
 "ai" = (
@@ -109,12 +101,6 @@
 /area/tcommsat/server)
 "ay" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
@@ -134,6 +120,16 @@
 	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
+"aC" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/crew_quarters/dorms)
 "aD" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/cable{
@@ -168,17 +164,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
-"aK" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
 "aO" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -186,11 +171,6 @@
 	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/engine/gravity_generator)
-"aP" = (
-/obj/effect/turf_decal/tile/ship/half/green,
-/obj/structure/table/glass,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
 "aS" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
@@ -209,17 +189,13 @@
 /obj/item/kitchen/fork,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
-"aX" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
+"aU" = (
+/obj/item/cardboard_cutout/adaptive,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "aY" = (
 /obj/machinery/door/airlock/ship/command{
 	name = "AI Core SMES";
@@ -271,8 +247,21 @@
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 4;
+	id = "cookshut"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/kitchen)
+"bq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "bs" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -296,15 +285,52 @@
 	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/engine/gravity_generator)
+"bv" = (
+/obj/structure/hull_plate,
+/obj/structure/chair,
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
+"bx" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/crew_quarters/dorms)
 "by" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
+"bz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "bA" = (
 /turf/open/space/basic,
 /area/space/nearstation)
+"bE" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/openspace,
+/area/maintenance/nsv/deck2/frame1/central)
 "bH" = (
 /obj/structure/fluff/bleepypanel{
 	dir = 4
@@ -352,7 +378,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "bS" = (
-/turf/open/indestructible/sound/pool/end,
+/obj/structure/table/glass,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "bT" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -393,17 +422,19 @@
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
 "bZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "atlas_xo"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/xo)
 "ce" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -411,6 +442,35 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"ch" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/sop/service{
+	pixel_x = -3
+	},
+/obj/item/flashlight/lamp/bananalamp{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/filled/nuka_cola{
+	pixel_x = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
+"ci" = (
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/steel,
+/area/maintenance/nsv/deck1/starboard)
 "cj" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 4
@@ -432,20 +492,21 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "ck" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/maintenance/nsv/deck2/frame1/port)
+"cl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/obj/machinery/computer/security{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/crew_quarters/dorms)
 "cm" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/ladder,
@@ -471,26 +532,17 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
-"ct" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Bridge";
-	departmentType = 5;
-	name = "Bridge RC";
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "cx" = (
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "cy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
+/obj/item/bedsheet/cmo,
+/obj/structure/bed/pod,
+/obj/machinery/firealarm/directional/west{
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/cmo)
 "cz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -534,10 +586,9 @@
 /turf/open/space/basic,
 /area/space)
 "cM" = (
-/obj/machinery/space_heater,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/mirror,
+/turf/closed/wall/r_wall,
+/area/crew_quarters/bar/mess_hall)
 "cN" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -556,6 +607,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
+"cP" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/hallway/nsv/deck1/hallway)
 "cQ" = (
 /obj/structure/cable{
 	icon_state = "2-10"
@@ -563,16 +618,14 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat)
 "cU" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/computer/ship/viewscreen,
+/obj/structure/bed/dogbed/ian{
+	color = "";
+	desc = "Skipper's bed! Looks comfy.";
+	name = "Dog Bed"
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/keycard_auth{
-	pixel_x = -25;
-	pixel_y = 25
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/mob/living/simple_animal/pet/dog/corgi/Ian{
+	name = "Galactica"
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
@@ -606,6 +659,19 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"da" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
 "db" = (
 /obj/structure/railing{
 	dir = 8
@@ -631,21 +697,28 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"dh" = (
+/obj/structure/table/glass,
+/obj/item/stamp/clown,
+/obj/item/reagent_containers/food/snacks/cakeslice/clown_slice,
+/obj/item/paper{
+	text = "Do a little trolling"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "dk" = (
-/obj/structure/extinguisher_cabinet/north,
-/obj/structure/closet/secure_closet/bridge,
-/turf/open/floor/monotile/steel,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "atlas_brief"
+	},
+/turf/open/floor/plating,
 /area/bridge/cic)
 "dl" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 1
+/obj/machinery/computer/squad_manager{
+	dir = 1;
+	icon_state = "computer"
 	},
-/obj/machinery/button/door{
-	id = "atlas_xo";
-	name = "courtroom_shutter";
-	pixel_x = -32
-	},
-/obj/machinery/light_switch/south,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "dn" = (
@@ -658,34 +731,29 @@
 /turf/open/floor/engine,
 /area/maintenance/nsv/deck2/frame1/port)
 "do" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_cap"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/chair/office{
 	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/window/westleft,
-/obj/machinery/door/window/eastright{
-	req_one_access_txt = "20"
-	},
+/obj/effect/landmark/start/captain,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "dp" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/nuke_storage)
+"dr" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/grid/lino,
+/area/medical/medbay)
 "dt" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/box,
@@ -693,11 +761,16 @@
 /turf/open/floor/plasteel/grid/techfloor,
 /area/ai_monitored/turret_protected/ai)
 "dv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "atlas_xo"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -705,8 +778,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/window/eastleft{
+	req_one_access_txt = "57"
+	},
 /turf/open/floor/monotile/steel,
-/area/bridge/cic)
+/area/crew_quarters/heads/xo)
 "dw" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
@@ -728,7 +808,7 @@
 "dy" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing,
-/obj/item/paper_bin,
+/obj/item/radio/intercom,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "dz" = (
@@ -757,21 +837,7 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"dC" = (
-/obj/effect/landmark/start/bridge,
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "dE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/ship/yellow{
 	dir = 1
 	},
@@ -782,10 +848,11 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "dF" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/structure/ladder,
-/turf/open/openspace,
-/area/maintenance/nsv/deck2/frame1/central)
+/obj/structure/hull_plate/end{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/nsv/deck2/frame1/port)
 "dH" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -823,21 +890,35 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/table/wood,
-/obj/item/storage/box/squad_lanyards,
-/obj/item/stamp/hop,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/xo)
-"dW" = (
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 5
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/xo)
+"dT" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/instrument/accordion,
+/obj/machinery/button/door{
+	dir = 8;
+	id = "atlas_dorm_1";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = -32;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/crew_quarters/dorms)
+"dW" = (
+/obj/machinery/light_switch/south,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "dX" = (
-/obj/machinery/vending/boozeomat,
-/turf/closed/wall/steel,
-/area/crew_quarters/heads/xo)
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "dY" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/structure/cable{
@@ -848,28 +929,24 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "eb" = (
-/obj/item/twohanded/required/kirbyplants/photosynthetic,
-/turf/open/floor/carpet/ship,
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "ec" = (
-/obj/effect/turf_decal/tile/ship/blue{
-	dir = 8;
-	icon_state = "bordercorner"
-	},
-/obj/effect/turf_decal/tile/ship/blue{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/multiz,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/port)
+"ee" = (
+/obj/structure/dresser,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/light_switch/east,
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
-"ee" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "ef" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/circuit/telecomms/server,
@@ -886,11 +963,9 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "ei" = (
-/obj/structure/table/reinforced,
-/obj/structure/railing,
-/obj/item/radio/intercom,
-/turf/open/floor/carpet/royalblack,
-/area/bridge/cic)
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "ej" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -901,24 +976,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
-"ek" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "em" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
 "en" = (
-/obj/structure/dresser,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/sound/pool,
 /area/crew_quarters/bar/mess_hall)
 "ep" = (
 /obj/machinery/computer/cloning,
@@ -957,11 +1021,20 @@
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"eA" = (
+/obj/machinery/modular_computer/console/preset/command,
+/obj/machinery/button/door{
+	id = "atlas_cap";
+	name = "courtroom_shutter";
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/heads/captain)
 "eC" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/xo)
 "eD" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -975,18 +1048,6 @@
 /obj/effect/spawner/room/fivexthree,
 /turf/template_noop,
 /area/maintenance/nsv/deck2/frame1/port)
-"eH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "eI" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -1035,59 +1096,23 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
-"eP" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "atlas_brief";
-	name = "Bridge Shutters";
-	pixel_y = 2
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "eS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar/mess_hall)
-"fa" = (
-/turf/open/floor/plasteel/stairs{
-	dir = 8
-	},
-/area/bridge/cic)
-"fd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
-"fe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
-"ff" = (
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
+"fe" = (
+/obj/structure/hull_plate,
+/turf/closed/wall/r_wall,
+/area/maintenance/nsv/deck2/frame1/port)
+"fi" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating,
+/area/hallway/nsv/deck1/hallway)
 "fl" = (
 /obj/machinery/door/airlock/ship/public{
 	name = "Cold Room";
@@ -1111,15 +1136,16 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/kitchen)
 "fm" = (
-/obj/structure/closet/secure_closet/hos,
-/obj/item/storage/secure/safe/HoS{
-	pixel_x = 8;
-	pixel_y = 24
-	},
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/item/bedsheet/hos,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/stamp/hos,
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = -5;
+	pixel_y = 6
+	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "fn" = (
@@ -1149,15 +1175,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"fp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
-"fs" = (
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/bar/mess_hall)
 "ft" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1168,29 +1185,13 @@
 /obj/effect/turf_decal/tile/ship/brown{
 	dir = 8
 	},
-/obj/effect/landmark/start/bridge,
-/obj/structure/chair/office{
-	dir = 8
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "fv" = (
-/obj/machinery/button/door{
-	dir = 8;
-	id = "atlas_toilet_1";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_x = 22;
-	pixel_y = 24;
-	specialfunctions = 4
-	},
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/obj/structure/mirror{
-	pixel_y = 35
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "fw" = (
 /obj/structure/cable{
@@ -1227,21 +1228,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
-"fF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "fH" = (
 /obj/structure/chair/stool,
 /obj/structure/cable{
@@ -1278,9 +1264,10 @@
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
 "fR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/stamp/rd,
+/obj/item/paper_bin,
+/mob/living/simple_animal/pet/hamster/vector,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
 "fS" = (
@@ -1335,6 +1322,11 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat)
+"gg" = (
+/obj/structure/hull_plate,
+/obj/machinery/ship_weapon/deck_turret/east,
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "gi" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/freezer,
@@ -1352,6 +1344,22 @@
 "gq" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck2/frame1/central)
+"gs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "gu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1373,6 +1381,15 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"gB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "gC" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 4
@@ -1408,6 +1425,16 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
+"gI" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "gK" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
@@ -1419,19 +1446,35 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "gM" = (
-/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/open/openspace,
-/area/maintenance/nsv/deck2/frame1/central)
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "gN" = (
-/obj/structure/table/reinforced,
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
-/area/bridge/cic)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"gP" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/soap/nanotrasen,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "gQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -1460,31 +1503,15 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "gU" = (
+/obj/machinery/door/airlock/ship/maintenance,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/command/glass{
-	name = "Chief Engineer";
-	req_one_access_txt = "56"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/chief)
-"gW" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/megaphone/command,
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/port)
 "gX" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
@@ -1516,16 +1543,26 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
-"ha" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
+"hc" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-9"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
+"hf" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Auxiliary Shuttle Dock"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/bridge/cic)
+/area/hallway/nsv/deck1/hallway)
+"hg" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "hh" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -1534,10 +1571,21 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat)
+"hi" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/dorms)
 "hk" = (
 /obj/structure/sign/ship/deck,
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame1/port)
+"hn" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "hq" = (
 /obj/machinery/computer/ship/dradis{
 	dir = 8
@@ -1551,26 +1599,20 @@
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "hr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship,
-/area/crew_quarters/dorms)
-"ht" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
-"hx" = (
-/obj/item/storage/secure/safe/caps_spare,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"ht" = (
+/obj/machinery/vending/boozeomat,
+/turf/closed/wall/steel,
 /area/bridge/cic)
 "hy" = (
 /obj/structure/cable{
@@ -1581,21 +1623,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
-"hz" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "hA" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "hE" = (
@@ -1610,11 +1644,27 @@
 /turf/open/floor/engine/airless,
 /area/ai_monitored/turret_protected/ai)
 "hI" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/south,
-/turf/open/floor/wood,
+/obj/structure/closet/boxinggloves,
+/obj/item/clothing/under/shorts/grey,
+/obj/item/clothing/under/shorts/grey,
+/obj/item/clothing/under/shorts/grey,
+/obj/item/clothing/under/shorts/purple,
+/obj/item/clothing/under/shorts/purple,
+/obj/item/clothing/under/shorts/red,
+/obj/item/clothing/under/shorts/red,
+/obj/item/clothing/under/shorts/blue,
+/obj/item/clothing/under/shorts/blue,
+/obj/item/twohanded/required/pool/pool_noodle,
+/obj/item/twohanded/required/pool/pool_noodle,
+/obj/item/twohanded/required/pool/pool_noodle,
+/obj/item/twohanded/required/pool/pool_noodle,
+/obj/item/twohanded/required/pool/rubber_ring,
+/obj/item/twohanded/required/pool/rubber_ring,
+/obj/item/twohanded/required/pool/rubber_ring,
+/obj/item/twohanded/required/pool/rubber_ring,
+/obj/item/twohanded/required/pool/rubber_ring,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "hJ" = (
 /turf/open/floor/monotile/dark,
@@ -1681,17 +1731,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
-"ij" = (
-/obj/structure/closet/radiation,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
-"ik" = (
-/obj/structure/closet/secure_closet/bridge,
-/turf/open/floor/monotile/steel,
-/area/bridge/cic)
 "in" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1704,16 +1743,8 @@
 /turf/open/floor/monotile/dark,
 /area/medical/chemistry)
 "ir" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/bridge,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -1760,29 +1791,15 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/nsv/deck2/frame1/port)
-"iB" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/computer/security/mining{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "iD" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/machinery/computer/communications,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/captain)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/soapstone/infinite,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/port)
 "iE" = (
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/nuke_storage)
@@ -1796,18 +1813,14 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
 "iG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/computer/station_alert{
-	dir = 8;
-	name = "ship alert console"
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
+/area/maintenance/nsv/deck2/frame1/port)
 "iH" = (
 /obj/structure/sign/poster/contraband/communist_state,
 /turf/closed/wall/r_wall,
@@ -1842,6 +1855,14 @@
 /area/hallway/nsv/deck1/hallway)
 "iJ" = (
 /obj/effect/turf_decal/tile/ship/half/blue,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "iN" = (
@@ -1859,30 +1880,17 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck2/frame1/port)
-"iP" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/computer/atmos_alert{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
+"iQ" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/instrument/eguitar,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/crew_quarters/dorms)
 "iS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/firecloset/full,
+/obj/vehicle/ridden/bicycle,
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck1/starboard)
+/area/crew_quarters/dorms)
 "iU" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
@@ -1894,21 +1902,11 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "iW" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "iX" = (
 /obj/effect/decal/cleanable/glitter/white{
 	layer = 4.1;
@@ -1954,15 +1952,14 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
-"je" = (
-/obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
 "jf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/brown{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
@@ -1971,13 +1968,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "jk" = (
 /obj/structure/railing{
@@ -2017,9 +2018,6 @@
 /area/security/detectives_office)
 "jn" = (
 /obj/machinery/computer/secure_data/laptop,
-/obj/item/paper_bin,
-/obj/item/stamp/hos,
-/obj/item/clothing/mask/cigarette/cigar,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -2029,6 +2027,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"js" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "ju" = (
 /turf/open/floor/plasteel/grid/lino,
 /area/tcommsat/server)
@@ -2044,19 +2055,19 @@
 "jx" = (
 /obj/structure/sign/ship/deck,
 /turf/closed/wall/r_wall,
-/area/hallway/nsv/deck1/hallway)
-"jB" = (
-/obj/machinery/camera/autoname,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/ship/green{
+/area/bridge/cic)
+"jA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/green,
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/crew_quarters/dorms)
 "jG" = (
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet/red,
@@ -2077,6 +2088,25 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck2/frame1/port)
+"jL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"jO" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/slapper,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "jQ" = (
 /obj/structure/fluff/bleepypanel{
 	dir = 8
@@ -2112,13 +2142,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "jX" = (
-/obj/structure/table/wood/fancy,
-/obj/item/camera,
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 1
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/bar/mess_hall)
 "jZ" = (
 /obj/machinery/power/solar_control{
@@ -2131,31 +2159,17 @@
 /turf/open/floor/plasteel/grid/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "ka" = (
+/obj/machinery/jukebox,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
-"kb" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "atlas_brief"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/bridge/cic)
-"ke" = (
-/obj/effect/turf_decal/tile/ship/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/ship/brown{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
+"kd" = (
+/obj/machinery/stasis,
+/obj/item/bedsheet/medical,
+/turf/open/floor/plasteel/grid/lino,
+/area/medical/medbay)
 "kh" = (
 /obj/structure/railing{
 	dir = 1
@@ -2173,24 +2187,33 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "ki" = (
-/obj/structure/extinguisher_cabinet/east,
-/obj/machinery/light_switch/south,
-/obj/structure/displaycase/captain,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/captain)
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "km" = (
-/obj/machinery/vending/clothing,
+/obj/machinery/washing_machine,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "ku" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/monotile/steel,
+/obj/structure/table/reinforced,
+/obj/structure/railing,
+/obj/item/paper_bin,
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
+"kv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "atlas_cap"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain)
 "kw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -2207,21 +2230,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/monotile/steel,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "kz" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/spawner/lootdrop/glowstick,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "kB" = (
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/monotile/dark,
@@ -2250,11 +2276,19 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"kM" = (
+"kL" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
+"kM" = (
+/obj/machinery/door/airlock/ship/command{
+	name = "Executive Officer's Office";
+	req_one_access_txt = "57"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "kN" = (
 /obj/structure/hull_plate,
@@ -2301,24 +2335,6 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
-"kT" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/computer/cargo/request{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "kX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2402,6 +2418,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai)
+"ld" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/dorms)
 "le" = (
 /obj/structure/grille,
 /turf/open/floor/engine/airless,
@@ -2429,6 +2457,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"li" = (
+/obj/item/bedsheet/hop{
+	name = "executive officer's bedsheet"
+	},
+/obj/structure/bed/pod,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/xo)
+"lk" = (
+/turf/open/floor/plasteel/stairs{
+	dir = 8
+	},
+/area/bridge/cic)
 "ll" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Hydroponics";
@@ -2437,8 +2477,14 @@
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/area/crew_quarters/bar/mess_hall)
 "ln" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -2465,10 +2511,25 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat)
+"lv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "lw" = (
-/obj/machinery/pool_filter,
-/obj/machinery/airalarm/directional/north,
-/turf/open/indestructible/sound/pool/end,
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "lx" = (
 /turf/closed/wall/r_wall,
@@ -2514,14 +2575,20 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "lJ" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/instrument/violin,
-/obj/item/instrument/harmonica,
-/obj/item/instrument/banjo,
 /obj/machinery/light_switch/west,
-/obj/effect/spawner/lootdrop/costume,
-/turf/open/floor/carpet/ship,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
+"lK" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "lL" = (
 /turf/open/floor/bronze,
 /area/ai_monitored/turret_protected/ai)
@@ -2552,7 +2619,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/xo)
 "lO" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -2568,9 +2635,7 @@
 /obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 5
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "ma" = (
@@ -2578,6 +2643,13 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
+"mb" = (
+/obj/structure/hull_plate/end{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "mf" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/box,
@@ -2587,30 +2659,35 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
-"mh" = (
-/obj/structure/chair/office/light,
-/obj/machinery/keycard_auth{
-	pixel_x = -25;
-	pixel_y = -6
-	},
-/obj/effect/landmark/start/chief_engineer,
-/obj/machinery/firealarm/directional/west{
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/chief)
-"ml" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
-"mm" = (
-/obj/machinery/light/small,
-/obj/machinery/computer/card/minor/rd{
+"mj" = (
+/obj/effect/turf_decal/tile/ship/brown{
 	dir = 1
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
+/obj/effect/turf_decal/tile/ship/brown{
+	dir = 8
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/bridge,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
+"ml" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/port)
+"mm" = (
+/obj/machinery/door/airlock/ship/command{
+	name = "Research Director";
+	req_access_txt = "30";
+	req_one_access_txt = "30"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/hor)
 "mr" = (
 /obj/structure/cable{
@@ -2622,8 +2699,15 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/captain,
-/turf/open/floor/monotile/steel,
+/obj/structure/bed/dogbed/ian{
+	color = "";
+	desc = "Skipper's bed! Looks comfy.";
+	name = "Dog Bed"
+	},
+/mob/living/simple_animal/pet/dog/pug{
+	name = "pugasus"
+	},
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "ms" = (
 /obj/structure/chair/office/light{
@@ -2640,8 +2724,8 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "mv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/xo)
@@ -2669,12 +2753,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"mC" = (
-/obj/effect/turf_decal/pool{
-	dir = 1
-	},
-/turf/open/floor/monotile/light,
-/area/crew_quarters/bar/mess_hall)
 "mE" = (
 /obj/structure/rack,
 /obj/item/storage/secure/briefcase,
@@ -2746,6 +2824,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/maintenance/nsv/deck2/frame1/port)
+"nd" = (
+/obj/structure/table/wood/fancy/blue,
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/cmo)
 "nf" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/box,
@@ -2757,6 +2840,12 @@
 	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/ai_monitored/turret_protected/ai)
+"ng" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "nh" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "Network Administration";
@@ -2773,9 +2862,8 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat)
 "nk" = (
-/obj/effect/landmark/start/mime,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/sound/pool,
 /area/crew_quarters/bar/mess_hall)
 "nr" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -2789,11 +2877,28 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "ns" = (
-/obj/structure/sign/ship/nosmoking{
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
+"nA" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/bridge/cic)
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
+"nC" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "nD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -2832,10 +2937,10 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "nK" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "nL" = (
@@ -2866,6 +2971,23 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
+"nN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "nS" = (
 /obj/machinery/telecomms/server/presets/service,
 /obj/machinery/light,
@@ -2875,6 +2997,13 @@
 /obj/structure/sign/ship/deck,
 /turf/closed/wall/steel,
 /area/bridge/cic)
+"nX" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "oa" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -2933,9 +3062,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
 "ok" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "ol" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2957,6 +3086,10 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
+"on" = (
+/obj/structure/sign/ship/smoking,
+/turf/closed/wall/r_wall,
+/area/crew_quarters/bar/mess_hall)
 "oo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -2971,17 +3104,26 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
+"or" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/green,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "ot" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -3002,31 +3144,28 @@
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "ox" = (
-/obj/effect/turf_decal/pool{
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/closet/boxinggloves,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/red,
-/obj/item/twohanded/required/pool/pool_noodle,
-/obj/item/twohanded/required/pool/pool_noodle,
-/obj/item/twohanded/required/pool/pool_noodle,
-/obj/item/twohanded/required/pool/rubber_ring,
-/obj/item/twohanded/required/pool/rubber_ring,
-/obj/item/twohanded/required/pool/rubber_ring,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "Barshut"
+	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/bar/mess_hall)
+"oz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "oA" = (
 /obj/machinery/telecomms/hub/preset,
 /obj/machinery/camera/autoname,
@@ -3040,10 +3179,6 @@
 	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/ai_monitored/turret_protected/ai)
-"oD" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/crew_quarters/bar/mess_hall)
 "oE" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -3052,37 +3187,45 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
-"oH" = (
-/obj/machinery/computer/ship/helm{
+"oG" = (
+/obj/effect/turf_decal/tile/ship/green{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
 	},
-/turf/open/floor/carpet/royalblack,
-/area/bridge/cic)
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "oO" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/effect/landmark/nuclear_waste_spawner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/maintenance/nsv/deck1/starboard)
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/port)
 "oV" = (
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/chief)
-"oX" = (
-/obj/machinery/computer/robotics{
+/obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/light_switch/west{
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
+"oX" = (
+/obj/machinery/light_switch/east,
+/obj/item/radio/intercom/directional/south,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/light_switch/east,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
 "oY" = (
@@ -3093,24 +3236,17 @@
 /obj/machinery/computer/upload/ai{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "AI Upload";
-	dir = 10
-	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"pb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "dormsld"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "pc" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -25;
-	pixel_y = -6
-	},
 /obj/effect/landmark/start/head_of_security,
-/obj/machinery/firealarm/directional/west{
-	pixel_y = 12
-	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "pe" = (
@@ -3162,57 +3298,85 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
-"ps" = (
-/obj/machinery/light/small{
+"pm" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_x = -30
+/turf/open/floor/carpet/royalblack,
+/area/bridge/cic)
+"pq" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/central)
+"ps" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "pt" = (
 /obj/effect/spawner/room/fivexfour,
 /turf/template_noop,
 /area/maintenance/nsv/deck1/starboard)
+"pv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "pw" = (
-/turf/open/floor/carpet/blue,
+/obj/machinery/computer/monitor{
+	dir = 8;
+	name = "Bridge Power Monitoring Console"
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "px" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/ship/command{
-	name = "Executive Officer's Office";
-	req_one_access_txt = "57"
-	},
-/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/camera/autoname,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/north{
+	pixel_x = -6
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "pz" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/machinery/rnd/production/techfab/department/service,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "pB" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck1/starboard)
+"pC" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "pD" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/south,
+/obj/structure/extinguisher_cabinet/east,
+/obj/machinery/light_switch/south,
+/obj/structure/displaycase/captain,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "pE" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/recharge_station,
+/obj/machinery/camera{
+	c_tag = "AI Upload";
+	dir = 8
+	},
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/turret_protected/ai_upload)
 "pF" = (
@@ -3233,11 +3397,8 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "pH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10;
-	icon_state = "pipe"
-	},
-/turf/open/floor/carpet/blue,
+/obj/machinery/pool_filter,
+/turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/bar/mess_hall)
 "pJ" = (
 /obj/structure/table/optable,
@@ -3259,9 +3420,20 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "pM" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/sink{
+	pixel_y = 18
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "pO" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
@@ -3274,8 +3446,13 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "pU" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/stasis,
+/obj/item/bedsheet/medical,
+/obj/machinery/vending/wallmed{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/grid/lino,
+/area/medical/medbay)
 "qb" = (
 /obj/effect/spawner/room/threexthree,
 /turf/template_noop,
@@ -3291,9 +3468,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"qd" = (
+/obj/effect/spawner/lootdrop/pizzaparty,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/central)
 "qe" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/carpet/blue,
+/obj/item/twohanded/required/pool/pool_noodle,
+/turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/bar/mess_hall)
 "qf" = (
 /obj/structure/girder,
@@ -3316,18 +3498,13 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "qk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_xo"
-	},
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/obj/item/storage/box/squad_lanyards,
+/obj/item/stamp/hop,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "ql" = (
 /obj/structure/railing/corner{
@@ -3355,6 +3532,26 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"qm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/crew_quarters/dorms)
+"qq" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/dorms)
 "qs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3371,14 +3568,37 @@
 "qu" = (
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"qw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "qx" = (
 /obj/machinery/suit_storage_unit/cmo,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/cmo)
 "qz" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/sign/poster/contraband/smoke,
+/turf/closed/wall/r_wall,
+/area/crew_quarters/bar/mess_hall)
+"qA" = (
+/obj/machinery/door/airlock/ship/security{
+	name = "Head of Security";
+	req_one_access_txt = "58"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "qC" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3410,6 +3630,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
+"qL" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/item/toy/plush/carpplushie/dehy_carp,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/crew_quarters/dorms)
 "qM" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 4
@@ -3427,6 +3656,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
+"qQ" = (
+/obj/effect/turf_decal/tile/ship/half/green,
+/obj/structure/table/glass,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "qS" = (
@@ -3482,13 +3716,22 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar/mess_hall)
+"rd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "rf" = (
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "rg" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/nsv/deck2/frame1/port)
 "rh" = (
@@ -3503,6 +3746,7 @@
 /area/hallway/nsv/deck1/hallway)
 "rj" = (
 /obj/structure/extinguisher_cabinet/east,
+/obj/structure/table/wood,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "rk" = (
@@ -3521,6 +3765,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
+"rn" = (
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "atlas_xo";
+	name = "courtroom_shutter";
+	pixel_x = -32
+	},
+/obj/machinery/light_switch/south,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/heads/xo)
 "rr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3532,11 +3788,18 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "rs" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Research Director's Desk";
@@ -3545,10 +3808,10 @@
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/structure/extinguisher_cabinet/east,
+/obj/machinery/computer/card/minor/rd{
 	dir = 8
 	},
-/obj/item/stamp/rd,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
 "rt" = (
@@ -3560,9 +3823,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
 "rv" = (
-/obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/chief)
+/obj/structure/curtain,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/dorms)
 "rw" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3577,7 +3840,9 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat)
 "ry" = (
-/obj/machinery/recharge_station,
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "rA" = (
@@ -3587,14 +3852,21 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"rC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "rK" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
@@ -3605,6 +3877,17 @@
 /obj/structure/closet/l3closet,
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck1/starboard)
+"rM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/curtain/bounty,
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "rN" = (
 /obj/structure/table/reinforced,
 /obj/item/paicard,
@@ -3632,12 +3915,25 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "rT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/dorms)
+"rU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "captainofficeshutters"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "atlas_xo"
+	},
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck1/starboard)
+/area/crew_quarters/heads/xo)
 "rV" = (
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
@@ -3739,9 +4035,17 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "sh" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/light_switch/north,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/toy/plush/plushvar,
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
+"si" = (
+/obj/structure/hull_plate,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
 /area/crew_quarters/dorms)
 "sj" = (
 /obj/machinery/porta_turret/ai,
@@ -3749,15 +4053,17 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
+"sm" = (
+/obj/structure/closet/secure_closet/bridge,
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
 "sp" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/chief)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "ss" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3819,6 +4125,12 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/tcommsat/server)
+"sF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
 "sH" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -3840,7 +4152,7 @@
 /turf/open/floor/monotile/steel,
 /area/medical/medbay)
 "sJ" = (
-/turf/open/indestructible/sound/pool,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "sL" = (
 /obj/structure/chair/stool,
@@ -3907,6 +4219,19 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/kitchen)
+"sZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/obj/structure/cable{
+	icon_state = "8-9"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "ta" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -3923,8 +4248,17 @@
 /area/maintenance/nsv/deck1/starboard)
 "tb" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "td" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/rationpack,
@@ -3958,38 +4292,42 @@
 /turf/open/floor/bronze,
 /area/ai_monitored/turret_protected/ai)
 "tm" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/curtain/obscuring/grey{
+	icon_state = "closed";
+	opacity = 1;
+	open = 0
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/starboard)
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/dorms)
 "tp" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat)
+"tq" = (
+/obj/machinery/computer/mecha{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west{
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/crew_quarters/heads/hor)
 "ts" = (
-/obj/item/trash/waffles,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/closet/crate/hydroponics,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
+"tw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "tx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4025,6 +4363,13 @@
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
+"tE" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/advanced_airlock_controller/directional/west,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "tH" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/teleport/hub,
@@ -4054,6 +4399,12 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck2/frame1/port)
+"tK" = (
+/obj/structure/sign/ship/nosmoking{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/bridge/cic)
 "tM" = (
 /obj/effect/decal/cleanable/glitter/white{
 	layer = 4.1;
@@ -4089,11 +4440,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "tT" = (
-/obj/structure/closet/crate/secure/loot,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "tW" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating,
@@ -4106,23 +4455,36 @@
 /obj/machinery/power/apc/auto_name/west{
 	cell_type = /obj/item/stock_parts/cell/super
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/railing{
+	dir = 10
+	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "tZ" = (
-/obj/machinery/stasis,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/south,
-/obj/machinery/light_switch/south{
-	pixel_x = -10
-	},
-/obj/item/bedsheet/medical,
+/obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
 "ub" = (
 /obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_y = -28
+	},
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -4141,14 +4503,19 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ud" = (
-/obj/item/trash/sosjerky,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "uf" = (
 /obj/structure/hull_plate/end{
 	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
+"ug" = (
+/obj/structure/hull_plate,
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
@@ -4165,6 +4532,19 @@
 "uj" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
+"up" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/computer/station_alert{
+	dir = 8;
+	name = "ship alert console"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "ur" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker{
@@ -4200,18 +4580,22 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "uw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/door/airlock/ship/command/glass{
+	name = "Public EVA"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "ux" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/maintenance/five,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "uz" = (
@@ -4221,6 +4605,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
+"uA" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Bridge";
+	departmentType = 5;
+	name = "Bridge RC";
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
 "uG" = (
 /turf/closed/wall/steel,
 /area/crew_quarters/kitchen)
@@ -4230,7 +4627,12 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/cmo)
 "uI" = (
-/obj/effect/landmark/start/bartender,
+/obj/machinery/button/door{
+	id = "cookshut";
+	name = "Kitchen Shutter";
+	pixel_x = -36;
+	pixel_y = -3
+	},
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "uK" = (
@@ -4247,20 +4649,14 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "uN" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
-"uQ" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Auxiliary Shuttle Dock"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck1/hallway)
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "uR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -4278,10 +4674,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
@@ -4332,6 +4728,9 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "vd" = (
@@ -4349,16 +4748,34 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"ve" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "atlas_brief";
+	name = "Bridge Shutters";
+	pixel_y = 2
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "vf" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/south,
 /obj/item/storage/firstaid/regular,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
+"vh" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/crew_quarters/dorms)
 "vj" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -4394,14 +4811,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
+"vr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "vs" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
+/obj/structure/mirror{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/dorms)
 "vu" = (
 /obj/structure/railing{
 	dir = 1
@@ -4419,6 +4847,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
+"vC" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/item/toy/plush/beeplushie,
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/crew_quarters/dorms)
 "vD" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Genetics Lab";
@@ -4453,14 +4890,18 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "vI" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/vending/clothing,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4;
+	icon_state = "bordercorner"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1;
+	icon_state = "bordercorner"
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/starboard)
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "vJ" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating{
@@ -4468,21 +4909,12 @@
 	},
 /area/maintenance/nsv/deck2/frame1/port)
 "vK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/ship/preopen{
-	id = "captainofficeshutters"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_cap"
-	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
+/obj/item/bedsheet/captain,
+/obj/structure/bed/pod,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "vM" = (
 /obj/machinery/power/deck_relay,
@@ -4509,6 +4941,17 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"vS" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "vU" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -4531,6 +4974,12 @@
 /obj/machinery/ship_weapon/gauss_gun/north,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"vY" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/lino,
+/area/medical/medbay)
 "vZ" = (
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
@@ -4548,22 +4997,34 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/tcommsat/server)
+"wd" = (
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "we" = (
-/obj/structure/hull_plate,
-/obj/machinery/ship_weapon/deck_turret/east,
-/turf/open/floor/engine/airless,
-/area/space/nearstation)
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/dorms)
 "wg" = (
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/grid/mono,
+/turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "wi" = (
 /obj/machinery/door/airlock/ship/maintenance,
@@ -4591,6 +5052,18 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck1/starboard)
+"wm" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/item/toy/plush/slimeplushie,
+/turf/open/floor/carpet/ship/red_carpet,
+/area/crew_quarters/dorms)
+"wp" = (
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/crew_quarters/heads/hor)
 "ws" = (
 /obj/effect/turf_decal/tile/ship/blue{
 	dir = 1;
@@ -4621,6 +5094,12 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"wv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "wy" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/firealarm/directional/west,
@@ -4628,7 +5107,18 @@
 /area/medical/medbay)
 "wz" = (
 /turf/closed/wall/steel,
-/area/bridge/cic)
+/area/crew_quarters/heads/xo)
+"wB" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 13;
+	id = "ferry_home";
+	name = "port bay 2";
+	width = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "wF" = (
 /obj/machinery/smartfridge/drying_rack,
 /obj/machinery/power/apc/auto_name/north,
@@ -4641,16 +5131,44 @@
 "wH" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
+/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
 /turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
+"wJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "wK" = (
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"wN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "wO" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"wP" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/waterbottle/large,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "wS" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -4667,6 +5185,16 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
+"wT" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "wU" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4699,6 +5227,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
@@ -4727,7 +5264,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"xa" = (
+/obj/structure/sign/poster/contraband/kss13,
+/turf/closed/wall/r_wall,
+/area/crew_quarters/bar/mess_hall)
 "xd" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "xf" = (
@@ -4741,18 +5284,31 @@
 	name = "Executive requests console";
 	pixel_y = -32
 	},
-/obj/machinery/vending/cart{
-	density = 0;
-	pixel_x = 23
-	},
 /obj/item/squad_pager,
 /obj/item/squad_pager,
 /obj/item/storage/box/pinpointer_pairs,
-/turf/open/floor/monotile/steel,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/xo)
+"xk" = (
+/obj/structure/chair/comfy/shuttle{
+	color = "#696969";
+	dir = 4;
+	name = "helm officer"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/bridge/cic)
 "xl" = (
 /obj/machinery/camera/autoname,
-/turf/open/indestructible/sound/pool/end,
+/obj/structure/table/glass,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "xm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4795,29 +5351,19 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/chemistry)
 "xq" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/obj/item/stamp/ce,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 4;
-	name = "Chief Engineer RC";
-	pixel_y = 32
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/item/clothing/mask/cigarette/cigar{
-	pixel_x = -5;
-	pixel_y = 6
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/chief)
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "xr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -4825,17 +5371,21 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/blue,
 /area/bridge/cic)
+"xs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "xu" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Theatre"
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/monotile/steel,
+/obj/machinery/door/airlock/ship/public,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "xv" = (
 /obj/machinery/light/small{
@@ -4872,13 +5422,49 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "xB" = (
-/obj/item/twohanded/required/pool/pool_noodle,
-/turf/open/indestructible/sound/pool,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "xC" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/turret_protected/aisat)
+"xG" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"xH" = (
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
+	},
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1;
+	icon_state = "bordercorner"
+	},
+/obj/structure/dresser,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "xI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4895,6 +5481,12 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"xO" = (
+/obj/structure/closet/wardrobe/pjs,
+/obj/machinery/camera/autoname,
+/obj/effect/spawner/bundle/costume/sexyclown,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "xR" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -4903,16 +5495,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
-"xS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "atlas_brief"
-	},
-/turf/open/floor/plating,
-/area/bridge/cic)
 "xT" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /obj/effect/turf_decal/stripes/line{
@@ -4930,6 +5512,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
+"xV" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "atlas_brief"
+	},
+/turf/open/floor/plating,
+/area/bridge/cic)
 "xY" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
 	dir = 8
@@ -4944,11 +5536,13 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "ya" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/toy/cards/deck,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "yb" = (
 /turf/open/floor/monotile/dark/airless{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -4982,11 +5576,19 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "yh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/command{
+	name = "Captain's Office";
+	req_one_access_txt = "20"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
-/area/bridge/cic)
+/area/crew_quarters/heads/captain)
 "yl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5007,12 +5609,6 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/monotile/steel,
 /area/medical/medbay)
-"yp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "yq" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 26
@@ -5027,10 +5623,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"yu" = (
-/obj/structure/lattice/catwalk/over/ship,
-/turf/open/openspace,
-/area/maintenance/nsv/deck2/frame1/central)
 "yv" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -5056,6 +5648,16 @@
 "yx" = (
 /turf/open/openspace,
 /area/hallway/nsv/deck1/hallway)
+"yy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9;
+	icon_state = "pipe11-1"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "yz" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -5066,14 +5668,26 @@
 /turf/open/floor/plasteel/grid/techfloor,
 /area/engine/gravity_generator)
 "yB" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar/mess_hall)
+/obj/machinery/vending/autodrobe,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "yE" = (
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"yG" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "yJ" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
@@ -5103,6 +5717,10 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
+"yX" = (
+/obj/item/storage/secure/safe/caps_spare,
+/turf/closed/wall/r_wall,
+/area/bridge/cic)
 "yY" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -5149,21 +5767,54 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"zk" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/bridge,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
+"zm" = (
+/obj/structure/hull_plate,
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "zn" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/machinery/light_switch/east,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
 "zt" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "atlas_brief"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/bridge/cic)
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "zv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -5191,6 +5842,7 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
 /obj/item/stock_parts/matter_bin,
+/obj/item/toy/plush/narplush,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "zJ" = (
@@ -5210,10 +5862,7 @@
 	dir = 8;
 	icon_state = "bordercorner"
 	},
-/obj/effect/landmark/start/bridge,
-/obj/structure/chair/office{
-	dir = 8
-	},
+/obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "zK" = (
@@ -5221,23 +5870,13 @@
 /obj/structure/extinguisher_cabinet/north,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/storage/backpack/duffelbag/engineering,
+/obj/item/storage/toolbox/brass,
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/nsv/deck2/frame1/port)
 "zL" = (
+/obj/effect/turf_decal/tile/ship/half/green,
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -5253,6 +5892,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/blue,
 /area/bridge/cic)
+"zR" = (
+/obj/machinery/power/apc/highcap/fifteen_k{
+	pixel_x = 25;
+	pixel_y = -1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "zS" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -5280,9 +5930,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "zY" = (
@@ -5327,9 +5975,14 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "Ad" = (
-/obj/machinery/computer/squad_manager{
-	dir = 1;
-	icon_state = "computer"
+/obj/machinery/pdapainter{
+	pixel_y = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/vending/cart{
+	density = 0;
+	pixel_x = 23
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
@@ -5354,6 +6007,26 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
+"Ah" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "Aj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -5367,6 +6040,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/light,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "Am" = (
@@ -5383,26 +6057,35 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "Ao" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/blue,
+/turf/closed/wall/r_wall,
 /area/crew_quarters/heads/xo)
 "Ar" = (
-/obj/item/bedsheet/black,
-/obj/structure/bed/pod,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
+"At" = (
+/obj/structure/closet/radiation,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "Ax" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -5415,40 +6098,51 @@
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
+"AB" = (
+/mob/living/simple_animal/pet/penguin/emperor/shamebrero,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "AC" = (
-/obj/machinery/camera/autoname,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/north{
-	pixel_x = -6
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/keycard_auth{
+	pixel_x = -25;
+	pixel_y = 25
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "AE" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "AG" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
+"AH" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/crew_quarters/dorms)
 "AJ" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -5457,10 +6151,10 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
 "AP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/table/glass,
+/obj/item/hourglass,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "AT" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/ship/half/green,
@@ -5487,6 +6181,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
+"AZ" = (
+/obj/structure/closet/wardrobe/pink,
+/obj/effect/spawner/bundle/costume/sexymime,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "Bc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -5496,6 +6195,23 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"Be" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "captainofficeshutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "atlas_xo"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/xo)
 "Bh" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
@@ -5537,6 +6253,16 @@
 	},
 /turf/open/floor/plasteel/ship/riveted,
 /area/maintenance/nsv/deck2/frame1/port)
+"Bo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Bp" = (
 /obj/structure/fluff/vls_hatch,
 /turf/open/openspace,
@@ -5558,29 +6284,28 @@
 	},
 /area/maintenance/nsv/deck2/frame1/port)
 "Bv" = (
+/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Engineering wing maintenance";
 	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/central)
-"By" = (
-/obj/machinery/computer/monitor{
-	dir = 8;
-	name = "Bridge Power Monitoring Console"
+"BC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
 	},
-/obj/structure/railing{
-	dir = 5
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
+/obj/structure/closet/crate/wooden/toy,
+/obj/item/pneumatic_cannon/pie/selfcharge,
+/obj/item/megaphone/clown,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "BD" = (
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
@@ -5654,6 +6379,15 @@
 	},
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat)
+"BP" = (
+/obj/machinery/computer/ship/dradis{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/bridge/cic)
 "BS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5684,6 +6418,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"Cg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "Ch" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -5691,6 +6432,22 @@
 /obj/effect/turf_decal/tile/ship/green,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Cj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/ship/public{
+	name = "Galley";
+	req_one_access_txt = "28;25"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/light,
+/area/crew_quarters/bar/mess_hall)
 "Ck" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -5702,30 +6459,22 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "Cp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/closet/secure_closet/hos,
+/obj/item/storage/secure/safe/HoS{
+	pixel_x = 8;
+	pixel_y = 24
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/obj/machinery/firealarm/directional/west{
+	pixel_y = 12
 	},
-/area/maintenance/nsv/deck2/frame1/port)
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "Cq" = (
 /obj/structure/sign/ship/deck{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/crew_quarters/heads/chief)
-"Cr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/chief)
-"Ct" = (
-/obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar/mess_hall)
+/area/crew_quarters/heads/cmo)
 "Cu" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall/r_wall,
@@ -5737,6 +6486,16 @@
 "Cx" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
+"Cz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "CC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5750,16 +6509,8 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "CE" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/secure_data/laptop,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/keycard_auth{
-	pixel_x = -25;
-	pixel_y = 25
-	},
+/obj/machinery/computer/ship/viewscreen,
+/obj/machinery/computer/communications,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "CF" = (
@@ -5768,12 +6519,20 @@
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
 "CI" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/openspace,
+/turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/central)
+"CK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "CN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5830,14 +6589,20 @@
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
 "CW" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil/random,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/sunglasses/advanced/garb/supergarb,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
+"CY" = (
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Da" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -5891,7 +6656,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/hallway/nsv/deck1/hallway)
+/area/crew_quarters/heads/hor)
 "Dk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5922,7 +6687,6 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "Ds" = (
-/obj/structure/railing,
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
 	},
@@ -5939,17 +6703,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Dt" = (
-/obj/structure/chair/sofa{
-	dir = 1
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4;
+	icon_state = "bordercorner"
 	},
-/obj/machinery/camera/autoname{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-10"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar/mess_hall)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Du" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -5998,11 +6764,16 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "DA" = (
-/obj/structure/chair/office/light,
 /obj/effect/landmark/start/research_director,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
 "DB" = (
@@ -6026,23 +6797,33 @@
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
 "DE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/hull_plate,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/turf/open/floor/engine/airless,
+/area/crew_quarters/dorms)
+"DI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/obj/machinery/computer/prisoner/management{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "DJ" = (
 /obj/structure/chair/comfy/shuttle{
 	color = "#696969";
@@ -6101,12 +6882,7 @@
 /area/hallway/nsv/deck1/hallway)
 "DS" = (
 /obj/machinery/light_switch/east,
-/obj/machinery/vending/wardrobe/bar_wardrobe{
-	pixel_x = -14
-	},
-/obj/machinery/vending/wardrobe/chef_wardrobe{
-	pixel_x = 5
-	},
+/obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "DU" = (
@@ -6148,6 +6924,20 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
+"Ef" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/obj/structure/extinguisher_cabinet/west,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Ei" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -6172,7 +6962,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/blue,
+/turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
 "Em" = (
 /turf/open/floor/monotile/steel,
@@ -6204,32 +6994,31 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "Er" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 2;
-	height = 13;
-	id = "ferry_home";
-	name = "port bay 2";
-	width = 5
+/obj/machinery/door/airlock/ship/external/glass{
+	name = "Auxiliary Shuttle Dock"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
+"Ev" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green,
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "Ey" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/ship/preopen{
-	id = "captainofficeshutters"
-	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_xo"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/xo)
 "EA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -6244,11 +7033,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
-"EC" = (
-/obj/effect/landmark/start/clown,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
 "EH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6276,12 +7060,14 @@
 /turf/open/floor/engine,
 /area/hallway/nsv/deck1/hallway)
 "EP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
+/obj/structure/sign/solgov_flag{
+	pixel_y = 30
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "ES" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/five,
@@ -6294,17 +7080,17 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "EZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/modular_computer/console/preset/command{
+/obj/machinery/computer/bounty{
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 9
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -6326,21 +7112,14 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "Fc" = (
-/obj/structure/chair/office{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/effect/landmark/start/head_of_personnel{
-	icon_state = "Executive Officer";
-	name = "Executive Officer"
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/xo)
+"Fe" = (
+/turf/closed/wall/r_wall,
+/area/crew_quarters/fitness/recreation)
 "Fg" = (
 /obj/machinery/chem_master,
 /obj/machinery/firealarm/directional/east,
@@ -6383,11 +7162,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer/security{
 	dir = 8
 	},
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -6410,6 +7192,18 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Fr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/dorms)
 "Fu" = (
 /obj/machinery/ai_slipper,
 /turf/open/floor/monotile/dark,
@@ -6417,9 +7211,6 @@
 "Fw" = (
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
-"Fy" = (
-/turf/open/floor/wood,
-/area/crew_quarters/bar/mess_hall)
 "FA" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/railing/corner{
@@ -6452,13 +7243,20 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "FF" = (
-/obj/machinery/pdapainter{
-	pixel_y = 4
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1;
+	icon_state = "bordercorner"
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/xo)
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4;
+	icon_state = "bordercorner"
+	},
+/obj/structure/sign/solgov_flag/right{
+	pixel_y = 30
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "FI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/smartfridge/disks,
@@ -6468,18 +7266,24 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
+"FK" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/cmo)
 "FL" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "FO" = (
-/obj/structure/closet/crate/wooden/toy,
-/obj/item/soap/deluxe,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/camera/autoname,
-/turf/open/floor/carpet/blue,
+/obj/item/toy/plush/carpplushie,
+/turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/bar/mess_hall)
 "FP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -6512,6 +7316,11 @@
 	},
 /turf/closed/wall/steel,
 /area/hallway/nsv/deck1/hallway)
+"FT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/port)
 "FU" = (
 /obj/machinery/light/small,
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -6552,6 +7361,32 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
+"Gc" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/suit_storage_unit/captain,
+/obj/machinery/airalarm/directional/north,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/captain)
+"Gd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Ge" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/five,
@@ -6561,6 +7396,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"Gg" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "Gh" = (
 /obj/machinery/nuclearbomb/selfdestruct{
 	name = "ship self destruct terminal"
@@ -6569,11 +7416,20 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/nuke_storage)
 "Gi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
 	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/chief)
+/obj/effect/turf_decal/ship/techfloor,
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
+"Gj" = (
+/obj/machinery/light_switch/east,
+/obj/item/bedsheet/rd,
+/obj/structure/bed/pod,
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/crew_quarters/heads/hor)
 "Gm" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 1
@@ -6607,6 +7463,24 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
+"Gs" = (
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"Gt" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/dorms)
 "Gu" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -6640,6 +7514,7 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat)
 "GG" = (
+/obj/structure/closet/radiation,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6651,6 +7526,16 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck1/starboard)
+"GK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "atlas_brief"
+	},
+/turf/open/floor/plating,
+/area/bridge/cic)
 "GM" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -6658,10 +7543,32 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
-"GT" = (
+"GO" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
+"GP" = (
 /turf/open/floor/carpet/blue,
+/area/bridge/cic)
+"GT" = (
+/obj/machinery/door/airlock/ship/command{
+	name = "Captain's Office";
+	req_one_access_txt = "20"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "GW" = (
 /obj/structure/fluff/bleepypanel,
@@ -6696,6 +7603,15 @@
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/openspace,
 /area/hallway/nsv/deck1/hallway)
+"He" = (
+/obj/structure/hull_plate,
+/obj/structure/ladder,
+/obj/machinery/door/window/brigdoor/northleft,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "Hg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6716,8 +7632,8 @@
 	dir = 4;
 	pixel_y = -6
 	},
-/turf/closed/wall/steel,
-/area/hallway/nsv/deck1/hallway)
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hos)
 "Hj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -6744,14 +7660,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/computer/prisoner/management{
+/obj/machinery/computer/secure_data{
 	dir = 8
 	},
 /obj/structure/railing{
-	dir = 6
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -6783,17 +7699,13 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/area/crew_quarters/heads/hor)
 "Hq" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/instrument/guitar,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/dorms)
 "Ht" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
@@ -6842,16 +7754,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/medical/medbay)
-"HF" = (
-/obj/effect/turf_decal/tile/ship/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/ship/blue{
-	dir = 8;
-	icon_state = "bordercorner"
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
 "HG" = (
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/frame1/port)
@@ -6864,12 +7766,10 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck2/frame1/port)
 "HK" = (
-/obj/structure/disposalpipe/trunk/multiz/down{
-	dir = 8
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/extinguisher_cabinet/east,
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "HL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/obscuring/grey{
@@ -6879,16 +7779,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
-"HN" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	name = "Auxiliary Shuttle Dock"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/nsv/deck1/hallway)
 "HP" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
@@ -6912,6 +7802,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
+"HU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/crew_quarters/dorms)
 "HX" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -6939,12 +7841,24 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "Ig" = (
+/obj/machinery/light/small,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
 "Ih" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "Ii" = (
@@ -6997,11 +7911,39 @@
 	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
+"In" = (
+/obj/machinery/suit_storage_unit/rd,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/crew_quarters/heads/hor)
 "Io" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
+"Ip" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "atlas_dorm_1";
+	name = "Crew Bunk"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "Ir" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -7057,10 +7999,25 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"II" = (
+/obj/machinery/computer/ship/helm{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/bridge/cic)
 "IJ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
+"IK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "IL" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/circuit/telecomms/server,
@@ -7071,14 +8028,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/computer/crew{
+/obj/machinery/computer/med_data{
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 10
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -7184,12 +8141,36 @@
 /obj/item/stock_parts/cell/crap,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"Jf" = (
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Ji" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/item/stack/cable_coil/random,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"Jj" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
 "Jk" = (
 /obj/structure/fluff/bleepypanel{
 	dir = 4
@@ -7233,10 +8214,14 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/closet/secure_closet/RD,
-/obj/item/bedsheet/rd,
+/obj/structure/displaycase/labcage,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
+"Jt" = (
+/obj/structure/hull_plate,
+/obj/machinery/light,
+/turf/open/floor/engine/airless,
+/area/hallway/nsv/deck1/hallway)
 "Jv" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -7275,10 +8260,15 @@
 /obj/machinery/light_switch/west{
 	pixel_y = 12
 	},
-/obj/item/bedsheet/cmo,
 /mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
+"JC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "JG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7297,10 +8287,6 @@
 /obj/effect/landmark/start/ai/secondary,
 /turf/open/floor/bronze,
 /area/ai_monitored/turret_protected/ai)
-"JL" = (
-/obj/structure/curtain/obscuring/grey,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
 "JM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7308,32 +8294,34 @@
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "JN" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
 "JO" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/closet/secure_closet/CMO,
+/obj/machinery/light_switch/west{
+	pixel_y = 12
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/maintenance/nsv/deck1/starboard)
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/cmo)
 "JP" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "atlas_toilet_1";
+	name = "Unit 1"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "JQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7376,10 +8364,16 @@
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "JU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/computer/ship/tactical{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "JV" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7409,11 +8403,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/table/wood,
-/obj/item/stamp/captain,
-/obj/item/pinpointer/nuke,
-/obj/item/disk/nuclear,
-/turf/open/floor/monotile/steel,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "Kd" = (
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -7449,21 +8442,26 @@
 "Km" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/item/hand_tele,
-/obj/machinery/firealarm/directional/east,
 /obj/machinery/requests_console{
 	department = "Captain";
 	departmentType = 4;
 	name = "Captain requests console";
 	pixel_y = 32
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "Kn" = (
-/obj/machinery/washing_machine,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/extinguisher_cabinet/north{
+	pixel_x = 24;
+	pixel_y = 31
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Kp" = (
@@ -7474,6 +8472,15 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
+"Kq" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/megaphone/command,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "Kr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7549,17 +8556,17 @@
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "KC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/ship/command{
+	name = "Chief Medical Officer";
+	req_access_txt = "40";
+	req_one_access_txt = "40"
+	},
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/cmo)
 "KD" = (
-/obj/machinery/computer/ship/dradis{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/extinguisher_cabinet/north,
+/obj/structure/closet/secure_closet/bridge,
+/turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "KI" = (
 /obj/machinery/chem_dispenser,
@@ -7574,8 +8581,12 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/xo)
 "KL" = (
@@ -7595,6 +8606,16 @@
 "KS" = (
 /turf/closed/wall/r_wall,
 /area/hydroponics)
+"KV" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	req_one_access_txt = "46"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
+"KW" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/grid/lino,
+/area/medical/medbay)
 "KX" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -7610,6 +8631,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"Lc" = (
+/obj/machinery/button/door{
+	id = "Barshut";
+	name = "Bar Shutter";
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "Ld" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -7624,18 +8653,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
-"Li" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/computer/ship/tactical{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/bridge/cic)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -7643,20 +8660,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/machinery/computer/med_data{
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/computer/security/mining{
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 8
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -7667,6 +8684,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/table/wood,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "cookshut"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
 "Lo" = (
@@ -7680,6 +8700,12 @@
 /obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Lr" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/instrument/harmonica,
+/turf/open/floor/carpet/ship/red_carpet,
+/area/crew_quarters/dorms)
 "Lt" = (
 /obj/structure/ladder,
 /obj/machinery/door/window{
@@ -7687,6 +8713,23 @@
 	},
 /turf/open/floor/engine,
 /area/hallway/nsv/deck1/hallway)
+"Lu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "captainofficeshutters"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "atlas_cap"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain)
 "Lw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7742,6 +8785,20 @@
 "LL" = (
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"LM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/bridge,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "LN" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/monotile/dark,
@@ -7771,21 +8828,21 @@
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck1/starboard)
 "LR" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/black,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "LS" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/hos,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Head of Security's Desk";
@@ -7793,43 +8850,35 @@
 	name = "Head of Security RC";
 	pixel_y = 26
 	},
+/obj/machinery/suit_storage_unit/hos,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "LT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "LU" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/steel,
-/area/maintenance/nsv/deck1/starboard)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/dorms)
 "LX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 17;
+	pixel_y = 9
+	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "Ma" = (
-/obj/structure/piano{
-	icon_state = "piano"
+/obj/effect/turf_decal/pool{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "Mb" = (
 /obj/machinery/camera/autoname{
@@ -7842,13 +8891,13 @@
 	},
 /area/security/detectives_office)
 "Mc" = (
-/obj/machinery/computer/mecha{
-	dir = 1
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/east,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/heads/hor)
+/obj/structure/railing,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "Mf" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -7869,6 +8918,17 @@
 /obj/machinery/power/solar,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
+"Mm" = (
+/obj/structure/table/glass,
+/obj/item/lighter/greyscale,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
+"Mn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/dorms)
 "Mo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7879,18 +8939,14 @@
 /turf/open/floor/monotile/steel,
 /area/medical/medbay)
 "Mp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_cap"
-	},
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/obj/item/stamp/captain,
+/obj/item/pinpointer/nuke,
+/obj/item/disk/nuclear,
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "Mq" = (
 /obj/machinery/light/small,
@@ -7904,6 +8960,29 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
+"Ms" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "atlas_dorm_2";
+	name = "Crew Bunk"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/dorms)
 "Mv" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -7916,9 +8995,27 @@
 /obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
+"My" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
 "Mz" = (
 /turf/open/floor/plasteel/grid/techfloor,
 /area/ai_monitored/turret_protected/ai)
+"MA" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/plasteel/grid/lino,
+/area/medical/medbay)
+"MC" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "atlas_brief"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/bridge/cic)
 "MD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7928,10 +9025,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
 "ME" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "atlas_dorm_1";
-	name = "Crew Bunk"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -7948,6 +9041,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/public{
+	name = "Dormitories"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "MF" = (
@@ -7979,6 +9075,19 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
+"MK" = (
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4;
+	icon_state = "bordercorner"
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "MN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7995,6 +9104,14 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "MQ" = (
@@ -8011,8 +9128,8 @@
 /obj/structure/sign/directions/supply{
 	pixel_y = -6
 	},
-/turf/closed/wall/steel,
-/area/hallway/nsv/deck1/hallway)
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hos)
 "MS" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck1/starboard)
@@ -8026,25 +9143,38 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
-"MZ" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+"MV" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "atlas_brief"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/bridge/cic)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/obj/machinery/button/door{
+	id = "dormsld";
+	name = "Dormitories Shutter";
+	pixel_x = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"MW" = (
+/obj/machinery/vending/toyliberationstation,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "Na" = (
-/obj/machinery/door/airlock/ship/public{
-	id_tag = "atlas_toilet_1";
-	name = "Unit 1"
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/dorms)
 "Nb" = (
@@ -8061,6 +9191,26 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Nd" = (
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Nf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8070,7 +9220,9 @@
 /area/ai_monitored/nuke_storage)
 "Ng" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/space_heater,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "Nj" = (
@@ -8116,19 +9268,37 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Np" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/bedsheetbin,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"Nr" = (
+/obj/machinery/door/airlock/ship/public{
+	id_tag = "atlas_dorm_3";
+	name = "Crew Bunk"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/area/crew_quarters/dorms)
 "Ns" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -8205,7 +9375,7 @@
 /turf/open/floor/monotile/steel,
 /area/medical/medbay)
 "ND" = (
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/sound/pool,
 /area/crew_quarters/bar/mess_hall)
 "NF" = (
 /obj/machinery/door/window/brigdoor/northleft{
@@ -8257,12 +9427,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "NJ" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/closet/secure_closet/bar,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "NK" = (
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
@@ -8282,33 +9452,47 @@
 	},
 /turf/closed/wall/r_wall,
 /area/hallway/nsv/deck1/hallway)
+"NO" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/turf/open/floor/plating,
+/area/hallway/nsv/deck1/hallway)
 "NP" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/ship/command{
-	name = "Captain's Office";
-	req_one_access_txt = "20"
-	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
+"NQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "captainofficeshutters"
+	},
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "atlas_cap"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain)
+"NS" = (
+/obj/structure/hull_plate/end{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "NX" = (
 /obj/machinery/light,
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "NY" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/computer/bounty{
+/obj/machinery/computer/cargo/request{
 	dir = 4
 	},
 /obj/structure/railing{
@@ -8316,6 +9500,15 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/railing{
+	dir = 10
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -8325,9 +9518,8 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "Oa" = (
-/obj/structure/curtain/obscuring/grey,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/blue,
+/obj/item/twohanded/required/pool/rubber_ring,
+/turf/open/indestructible/sound/pool,
 /area/crew_quarters/bar/mess_hall)
 "Od" = (
 /obj/structure/closet/crate,
@@ -8363,6 +9555,13 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"On" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "Oo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -8370,14 +9569,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
 "Op" = (
-/obj/effect/turf_decal/tile/ship/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/ship/brown{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/snacks/snowcones/clown,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "Ou" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/light/small{
@@ -8415,32 +9610,27 @@
 /obj/structure/cable{
 	icon_state = "5-10"
 	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "Oz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_xo"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/window/westright,
-/obj/machinery/door/window/eastleft{
-	req_one_access_txt = "57"
+/obj/effect/landmark/start/head_of_personnel{
+	icon_state = "Executive Officer";
+	name = "Executive Officer"
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
@@ -8462,6 +9652,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/openspace,
 /area/maintenance/nsv/deck2/frame1/port)
+"OH" = (
+/obj/machinery/door/airlock/ship/maintenance{
+	name = "Engineering wing maintenance";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/nsv/deck2/frame1/central)
 "OM" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Hydroponics";
@@ -8538,14 +9739,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Pe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/effect/turf_decal/tile/ship/half/green{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grid/mono,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Pf" = (
 /obj/effect/turf_decal/tile/ship/half/green,
@@ -8565,6 +9767,20 @@
 "Ph" = (
 /turf/template_noop,
 /area/maintenance/nsv/deck1/starboard)
+"Pi" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/instrument/banjo,
+/obj/machinery/button/door{
+	dir = 8;
+	id = "atlas_dorm_3";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = -32;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/crew_quarters/dorms)
 "Pk" = (
 /turf/closed/wall/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -8593,6 +9809,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"Pq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "Pu" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -8610,17 +9835,10 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "PE" = (
-/obj/structure/chair/office{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/obj/effect/landmark/start/captain,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "PF" = (
 /obj/structure/rack,
@@ -8658,6 +9876,16 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"PL" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/computer/robotics{
+	dir = 4
+	},
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/crew_quarters/heads/hor)
 "PM" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -8671,18 +9899,26 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
 "PO" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
+"PQ" = (
+/obj/structure/chair/sofa/left{
+	dir = 4
 	},
-/area/maintenance/nsv/deck2/frame1/port)
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "PT" = (
 /obj/machinery/cryopod,
 /turf/open/floor/carpet/green,
 /area/hallway/nsv/deck1/hallway)
 "PX" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/sign/solgov_flag{
+	pixel_y = 33
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "Qb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8711,34 +9947,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/bed/dogbed/ian{
-	color = "";
-	desc = "Skipper's bed! Looks comfy.";
-	name = "Dog Bed"
-	},
-/mob/living/simple_animal/pet/dog/pug{
-	name = "pugasus"
-	},
-/obj/item/bedsheet/captain,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
-"Qh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	id = "atlas_brief"
-	},
-/turf/open/floor/plating,
-/area/bridge/cic)
 "Qi" = (
-/obj/structure/chair/sofa/right{
-	dir = 8;
-	icon_state = "sofaend_right"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "Qk" = (
 /obj/machinery/vending/coffee,
@@ -8765,17 +9980,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
-"Qv" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 10;
-	icon_state = "camera"
-	},
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
 "Qw" = (
 /obj/effect/decal/cleanable/glitter/white{
 	layer = 4.1;
@@ -8806,14 +10010,10 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "QD" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/item/bedsheet/hos,
+/obj/structure/bed/pod,
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "QF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8825,6 +10025,12 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat)
+"QH" = (
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "QI" = (
 /obj/structure/sign/directions/engineering,
 /obj/structure/sign/directions/security{
@@ -8883,6 +10089,9 @@
 /obj/structure/railing{
 	dir = 6
 	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "Ra" = (
@@ -8911,10 +10120,31 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck2/frame1/port)
+"Rf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "Rg" = (
 /obj/structure/hull_plate/end,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"Rk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/orange_carpet,
+/area/crew_quarters/dorms)
 "Rl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8944,6 +10174,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/machinery/firealarm/directional/west{
+	pixel_y = 12
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -25;
+	pixel_y = -6
+	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "Rt" = (
@@ -8957,6 +10194,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Ru" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Rw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -8964,12 +10211,22 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Rx" = (
+/obj/effect/landmark/start/mime,
+/obj/structure/bed,
+/obj/item/bedsheet/mime,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "RC" = (
-/obj/machinery/modular_computer/console/preset/command,
-/obj/machinery/button/door{
-	id = "atlas_cap";
-	name = "courtroom_shutter";
-	pixel_x = -32
+/obj/structure/table/glass,
+/obj/machinery/computer/secure_data/laptop,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/keycard_auth{
+	pixel_x = -25;
+	pixel_y = 25
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
@@ -8982,6 +10239,9 @@
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck1/starboard)
 "RI" = (
@@ -8995,9 +10255,14 @@
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/turret_protected/ai_upload)
 "RK" = (
-/obj/machinery/light_switch/south,
-/turf/open/floor/wood,
-/area/crew_quarters/bar/mess_hall)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "RL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -9009,15 +10274,22 @@
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "RM" = (
-/obj/machinery/computer/card/minor/ce{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/west,
-/obj/machinery/camera/autoname{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/chief)
+/obj/structure/cable{
+	icon_state = "4-5"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
+"RN" = (
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "RQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -9044,6 +10316,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"RY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/obj/structure/extinguisher_cabinet/west,
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Sc" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -9097,6 +10382,14 @@
 "Sl" = (
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
+"So" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/solgov_flag/right{
+	pixel_y = 33
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "Sr" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -9112,6 +10405,25 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
+"Su" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/ship/public,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "Sx" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only,
@@ -9127,16 +10439,23 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "SE" = (
-/obj/machinery/button/door{
-	dir = 8;
-	id = "atlas_dorm_1";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_x = -32;
-	specialfunctions = 4
-	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/carpet/ship,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1;
+	icon_state = "bordercorner"
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 4;
+	icon_state = "bordercorner"
+	},
+/obj/structure/easel,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/storage/crayons,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "SF" = (
 /obj/structure/table/wood,
@@ -9171,6 +10490,8 @@
 "SN" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/light_switch/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "SP" = (
@@ -9200,10 +10521,20 @@
 	},
 /turf/open/floor/engine,
 /area/hallway/nsv/deck1/hallway)
+"SV" = (
+/turf/open/floor/plating,
+/area/hallway/nsv/deck1/hallway)
 "SX" = (
 /obj/structure/lattice,
 /turf/open/openspace,
 /area/maintenance/nsv/deck2/frame1/port)
+"SZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "Tb" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -9252,22 +10583,28 @@
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/nuke_storage)
 "Ti" = (
-/obj/machinery/computer/ship/viewscreen,
-/obj/structure/bed/dogbed/ian{
-	color = "";
-	desc = "Skipper's bed! Looks comfy.";
-	name = "Dog Bed"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/mob/living/simple_animal/pet/dog/corgi/Ian{
-	name = "Galactica"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/item/bedsheet/hop{
-	name = "executive officer's bedsheet"
+/obj/structure/cable{
+	icon_state = "1-6"
 	},
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/xo)
+/obj/structure/cable{
+	icon_state = "8-9"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Tk" = (
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "Tl" = (
 /obj/machinery/door/airlock/ship/security{
@@ -9288,19 +10625,18 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "Tq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/storage/box/masks,
-/obj/item/defibrillator/loaded,
-/obj/item/storage/firstaid/advanced,
-/obj/machinery/vending/wallmed{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
-/obj/item/clothing/neck/stethoscope,
-/turf/open/floor/plasteel/grid/lino,
-/area/medical/medbay)
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "2-6"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Tv" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/monotile/steel,
@@ -9313,16 +10649,11 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "Tz" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/camera/autoname{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/item/instrument/guitar,
-/obj/item/instrument/accordion,
-/obj/item/instrument/piano_synth,
-/obj/item/instrument/eguitar,
-/obj/effect/spawner/lootdrop/costume,
-/turf/open/floor/carpet/ship,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
 "TB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -9330,11 +10661,40 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/hallway/nsv/deck1/hallway)
+/area/crew_quarters/heads/hor)
+"TC" = (
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "TE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/nsv/deck1/hallway)
+"TF" = (
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
+	},
+/obj/effect/landmark/start/bridge,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "TH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9362,12 +10722,39 @@
 "TM" = (
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
-"TO" = (
-/obj/machinery/camera/autoname{
+"TP" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
+"TR" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/machinery/camera/autoname,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
+"TS" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
 	dir = 8
 	},
-/turf/open/floor/monotile/dark,
-/area/bridge/cic)
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "TU" = (
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -9417,9 +10804,7 @@
 /area/ai_monitored/nuke_storage)
 "Uc" = (
 /obj/machinery/firealarm/directional/west,
-/obj/structure/closet/secure_closet/bar,
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/item/clothing/under/rank/civilian/bartender,
+/obj/machinery/food_cart,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "Ud" = (
@@ -9430,18 +10815,20 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Uh" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/item/book/manual/wiki/rbmk,
-/obj/item/bedsheet/ce,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/chief)
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 4;
+	icon_state = "borderhalf"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Ui" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9490,41 +10877,32 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Un" = (
+/obj/structure/disposalpipe/trunk/multiz/down,
+/obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
-"Up" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/nsv/deck1/starboard)
-"Uq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/ship/preopen{
-	id = "captainofficeshutters"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_cap"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
+/area/maintenance/nsv/deck2/frame1/port)
+"Up" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
+"Uq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "Uw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -9533,12 +10911,15 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
 "Uy" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "UA" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/open/openspace,
 /area/maintenance/nsv/deck2/frame1/central)
@@ -9649,6 +11030,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "Va" = (
@@ -9665,8 +11048,11 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "Ve" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/dorms)
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/hallway/nsv/deck1/hallway)
 "Vg" = (
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -9704,13 +11090,20 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Vp" = (
-/obj/structure/displaycase/labcage,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
 	},
-/turf/open/floor/carpet/ship/beige_carpet,
-/area/crew_quarters/heads/hor)
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1;
+	icon_state = "bordercorner"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Vu" = (
 /obj/machinery/computer/upload/borg{
 	dir = 4
@@ -9728,9 +11121,21 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/machinery/door/airlock/ship/public,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
+"Vx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/bar/mess_hall)
 "VA" = (
 /obj/structure/sign/ship/nosmoking,
 /turf/closed/wall/steel,
@@ -9743,12 +11148,14 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
 "VD" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/wood,
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
-/obj/machinery/advanced_airlock_controller/directional/west,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/obj/effect/turf_decal/tile/ship/half/blue,
+/obj/machinery/cell_charger,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "VE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -9794,11 +11201,12 @@
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "VS" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/starboard)
+/obj/structure/table/wood,
+/obj/item/storage/box/cups,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/half/blue,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "VV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -9818,19 +11226,52 @@
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "VZ" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
+"Wa" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/instrument/piano_synth,
+/obj/machinery/button/door{
+	dir = 8;
+	id = "atlas_dorm_2";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = -32;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/dorms)
+"Wb" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/skub,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "Wd" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/door/airlock/ship/command{
+	name = "Executive Officer's Office";
+	req_one_access_txt = "57"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/monotile/steel,
-/area/bridge/cic)
+/area/crew_quarters/heads/xo)
 "Wf" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -9867,10 +11308,7 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "WD" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
+/obj/structure/chair/stool/bar,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "WE" = (
@@ -9957,10 +11395,26 @@
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/hallway)
+"Xd" = (
+/obj/machinery/door/airlock/ship/public{
+	name = "Galley";
+	req_one_access_txt = "28;25"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "Xf" = (
-/obj/structure/closet/secure_closet/CMO,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/heads/cmo)
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/tile/ship/half/blue,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Xg" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/grid/lino,
@@ -9984,21 +11438,12 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Xl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/ship/preopen{
-	id = "captainofficeshutters"
-	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "atlas_xo"
-	},
-/turf/open/floor/plating,
+/obj/structure/table/wood/fancy/blue,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/xo)
 "Xm" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -10016,15 +11461,22 @@
 /turf/open/openspace,
 /area/maintenance/nsv/deck2/frame1/central)
 "Xp" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
+/obj/structure/hull_plate,
+/obj/machinery/light{
 	dir = 8
 	},
+/turf/open/floor/engine/airless,
+/area/crew_quarters/heads/xo)
+"Xq" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/hallway)
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "Xv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10052,11 +11504,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "Xx" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/obj/effect/landmark/start/clown,
+/obj/structure/bed,
+/obj/item/bedsheet/clown,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "Xz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -10073,16 +11525,49 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
-"XG" = (
-/obj/machinery/power/deck_relay,
-/obj/structure/cable{
-	icon_state = "0-2"
+"XA" = (
+/obj/structure/closet/secure_closet/RD,
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/crew_quarters/heads/hor)
+"XE" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
-/obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/starboard)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/crew_quarters/dorms)
+"XF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "atlas_cap"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/window/westleft,
+/obj/machinery/door/window/eastright{
+	req_one_access_txt = "20"
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/heads/captain)
+"XG" = (
+/obj/machinery/light/small,
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/crew_quarters/heads/hor)
 "XH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10095,6 +11580,14 @@
 	},
 /obj/structure/table/reinforced,
 /obj/structure/railing,
+/obj/item/toy/plush/nukeplushie{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/disk/nuclear/fake/obvious{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "XK" = (
@@ -10108,12 +11601,20 @@
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "XS" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/firealarm/directional/west,
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/extinguisher_cabinet/north,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "XT" = (
@@ -10164,7 +11665,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"Yd" = (
+/turf/open/floor/monotile/dark,
+/area/bridge/cic)
 "Yj" = (
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "Yk" = (
@@ -10206,8 +11711,8 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
 "Yr" = (
-/obj/item/twohanded/required/pool/rubber_ring,
-/turf/open/indestructible/sound/pool,
+/obj/effect/landmark/start/bartender,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "Ys" = (
 /obj/structure/table/reinforced,
@@ -10236,34 +11741,37 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
+"Yv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/monotile/steel,
+/area/bridge/cic)
+"Yy" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/hallway)
 "Yz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
 "YB" = (
 /obj/structure/table/reinforced,
-/obj/effect/landmark/zebra_interlock_point,
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	pixel_x = 2;
-	pixel_y = 24
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = 1;
+	pixel_y = 13
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 4;
-	pixel_x = -5
-	},
-/obj/item/storage/box/drinkingglasses{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "YC" = (
@@ -10271,13 +11779,12 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "YD" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/camera/autoname,
+/obj/structure/cable{
+	icon_state = "2-6"
 	},
-/obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/fitness/recreation)
 "YF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10286,27 +11793,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
-"YK" = (
-/obj/structure/chair/comfy/shuttle{
-	color = "#696969";
-	dir = 4;
-	name = "helm officer"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/bridge/cic)
 "YL" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"YN" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/cmo)
 "YP" = (
 /obj/machinery/light,
 /obj/machinery/hydroponics/constructable,
@@ -10322,6 +11822,15 @@
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"YS" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/item/toy/plush/lizardplushie,
+/turf/open/floor/carpet/ship/purple_carpet,
+/area/crew_quarters/dorms)
 "YU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10358,20 +11867,35 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck2/frame1/port)
+"YZ" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/hallway)
 "Zb" = (
 /obj/machinery/iv_drip/saline,
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/grid/lino,
 /area/medical/medbay)
 "Zd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8;
+	icon_state = "bordercorner"
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-6"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-9"
 	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/frame1/port)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "Zf" = (
 /obj/machinery/vending/engineering,
 /obj/machinery/light/small{
@@ -10401,6 +11925,29 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"Zq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "Zr" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -10413,27 +11960,38 @@
 /turf/closed/wall/r_wall,
 /area/hydroponics)
 "Zt" = (
-/obj/machinery/computer/security/telescreen/ce{
-	pixel_y = 26
-	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light_switch/west{
+/obj/structure/rack,
+/obj/machinery/firealarm/directional/west{
 	pixel_y = 12
 	},
-/mob/living/simple_animal/parrot/Poly,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "ZA" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/poddoor/shutters/ship{
+	dir = 4;
+	id = "cookshut"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/kitchen)
+"ZB" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/ship/half/blue{
+	dir = 8;
+	icon_state = "borderhalf"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/dorms)
 "ZC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10450,12 +12008,26 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/carpet/blue,
 /area/bridge/cic)
+"ZG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/bar/mess_hall)
 "ZK" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
-/turf/open/indestructible/sound/pool/end,
+/obj/structure/table/glass,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/mess_hall)
 "ZL" = (
 /obj/structure/cable{
@@ -10474,7 +12046,7 @@
 "ZN" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/steel,
-/area/bridge/cic)
+/area/crew_quarters/heads/captain)
 "ZO" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms/server,
@@ -10490,6 +12062,12 @@
 /obj/item/trash/candy,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/frame1/port)
+"ZS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/crew_quarters/dorms)
 "ZU" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -36328,10 +37906,10 @@ cL
 cL
 cL
 cL
-cL
-jv
-mK
-mK
+HI
+dF
+fe
+fe
 yE
 vm
 WN
@@ -36585,10 +38163,10 @@ cL
 cL
 SP
 Cf
-Cf
-jv
-mK
-mK
+ck
+qO
+qO
+qb
 yE
 vm
 EB
@@ -36842,10 +38420,10 @@ SP
 SP
 Cf
 cL
-cL
-jv
-mK
-mK
+HI
+qO
+qO
+qO
 yE
 yE
 CV
@@ -37100,9 +38678,9 @@ cL
 Cf
 cL
 HI
-HI
-HI
-HI
+qO
+qO
+qO
 HI
 yE
 yE
@@ -37357,9 +38935,9 @@ Cf
 Cf
 ys
 HI
-qO
-qO
-qb
+HI
+gU
+HI
 HI
 HI
 HI
@@ -37367,7 +38945,7 @@ HI
 HI
 qf
 jI
-tb
+FT
 Xm
 HI
 fL
@@ -37614,10 +39192,10 @@ bA
 Cf
 bA
 HI
-qO
-qO
-qO
-YD
+LL
+LL
+LL
+LL
 OQ
 KZ
 Tb
@@ -37629,12 +39207,12 @@ KZ
 KZ
 KZ
 uS
-dK
-dK
+qw
+qw
 UX
-dK
-WQ
-dK
+qw
+ci
+qw
 rA
 fw
 xx
@@ -37871,21 +39449,21 @@ bA
 Cf
 bA
 HI
-qO
-qO
-qO
-HI
+OQ
+KZ
+iD
+oO
 Un
 MD
 YF
 Ld
 YX
-oV
-oV
-oV
-oV
-oV
-AE
+Am
+Am
+Am
+Am
+GM
+GM
 GM
 GM
 GM
@@ -37894,7 +39472,7 @@ GM
 JX
 Aa
 rV
-Ej
+Op
 GY
 WM
 MS
@@ -38128,22 +39706,22 @@ bY
 bY
 bY
 HI
-JP
-HI
-HI
-HI
-Zd
-HG
+QW
+OU
+OU
+OU
+OU
+OU
 HG
 wi
 rh
-oV
+Am
 Zt
-mh
-RM
+Gi
+Am
 cy
 JO
-KC
+GM
 uH
 ms
 JA
@@ -38385,39 +39963,39 @@ jm
 Sl
 Sl
 cI
-OQ
-TV
+QW
+OU
 Cp
-KZ
+oV
 QD
 Hi
 Hc
 kh
 gC
-oV
+Am
 sp
-Cr
-Uh
-cy
-oO
+Gi
+Am
+YN
+qh
 KC
-Xf
+qh
 qh
 CN
 Sk
 Vn
 Ds
-yx
+nA
 Pk
 ig
 dK
 dK
 WQ
 cF
-lr
+dK
+At
 MS
-MS
-mK
+lx
 Rg
 cL
 cL
@@ -38643,7 +40221,7 @@ gE
 HL
 pO
 QW
-jI
+OU
 ee
 kz
 HK
@@ -38651,13 +40229,13 @@ MR
 yx
 jk
 yx
-oV
-xq
+Am
+Em
 Gi
-rv
-cy
-JO
-KC
+Am
+nd
+FK
+GM
 qx
 zv
 Ny
@@ -38671,10 +40249,10 @@ zI
 pB
 pB
 Tf
-iS
+Ej
+Cg
 MS
-MS
-mK
+lx
 Rg
 cL
 cL
@@ -38902,18 +40480,18 @@ LL
 iO
 OU
 OU
-OU
+qA
 OU
 QI
 yx
 jk
 yx
-oV
+Am
 uw
-gU
-EP
+TE
+Am
 Cq
-tm
+GM
 GM
 tR
 IR
@@ -38922,16 +40500,16 @@ VB
 yx
 wZ
 yx
-Am
 Cx
 Cx
 Cx
 Cx
-zS
-rT
+Cx
+Cx
+Cx
+GY
 MS
-MS
-mK
+lx
 Rg
 cL
 cL
@@ -39156,7 +40734,7 @@ ln
 kZ
 HL
 LL
-iO
+iG
 OU
 Rp
 pc
@@ -39182,13 +40760,13 @@ WW
 Dh
 Jr
 Ik
-Vp
 Cx
-pB
+tq
+PL
+Cx
 GY
 MS
-MS
-mK
+lx
 Rg
 cL
 cL
@@ -39423,9 +41001,9 @@ Rt
 Kr
 Bs
 Nb
-Xv
 Bs
-Xv
+Bs
+Bs
 Ql
 Uf
 Bs
@@ -39440,10 +41018,10 @@ Hp
 Yz
 DA
 mm
+wp
+wp
 Cx
-pB
 GY
-MS
 MS
 lx
 cL
@@ -39696,11 +41274,11 @@ It
 TB
 fR
 Ig
-Mc
 Cx
+In
 XG
-vI
-Od
+Cx
+GY
 MS
 lx
 cL
@@ -39950,13 +41528,13 @@ gq
 eu
 sf
 cD
-Am
+Cx
 rs
 oX
 Cx
+XA
+Gj
 Cx
-MS
-LU
 RD
 MS
 lx
@@ -40207,13 +41785,13 @@ gq
 WV
 wu
 Sc
-Am
-Am
-Am
-Am
-Am
-Am
-Up
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
+Cx
 Ng
 MS
 lx
@@ -40460,8 +42038,8 @@ oZ
 uj
 uj
 Xn
-Pm
-MQ
+gq
+HA
 JR
 su
 af
@@ -40470,7 +42048,7 @@ tM
 WC
 iX
 BL
-VS
+dK
 Ih
 MS
 lx
@@ -40697,7 +42275,7 @@ lx
 HI
 HI
 HI
-ye
+ec
 IF
 Uw
 HI
@@ -40705,9 +42283,9 @@ OX
 Ch
 jb
 eN
-wu
-YC
-gq
+wg
+zL
+Bv
 UA
 uj
 NB
@@ -40716,10 +42294,10 @@ bI
 TU
 OS
 uj
-UA
-gq
+bE
+OH
 hA
-wu
+bz
 YC
 TE
 DK
@@ -40962,10 +42540,10 @@ Fq
 vR
 Pk
 HA
-DE
-Xp
-Bv
-gM
+wu
+Sc
+gq
+CI
 uj
 kK
 Bc
@@ -40974,9 +42552,9 @@ TU
 ja
 uj
 CI
-Bv
-wg
-zL
+gq
+MQ
+wu
 Sc
 Pk
 Qw
@@ -41212,7 +42790,7 @@ HI
 Rd
 Ji
 LL
-LL
+ml
 HI
 HI
 HG
@@ -41222,7 +42800,7 @@ MQ
 wu
 Sc
 gq
-yu
+CI
 uj
 fo
 uR
@@ -41230,7 +42808,7 @@ pE
 Eo
 zU
 uj
-yu
+CI
 gq
 MQ
 wu
@@ -41242,7 +42820,7 @@ Am
 Am
 Am
 Ej
-zS
+TP
 MS
 lx
 cL
@@ -41479,7 +43057,7 @@ IQ
 Qb
 Kp
 gq
-dF
+qd
 uj
 uj
 Ov
@@ -41487,9 +43065,9 @@ zY
 RI
 uj
 uj
-dF
-gq
-Hq
+pq
+Pm
+MU
 wu
 Sc
 XZ
@@ -41499,7 +43077,7 @@ FA
 rV
 Nn
 rV
-zS
+RN
 MS
 lx
 Cf
@@ -41734,8 +43312,8 @@ oj
 hk
 HT
 zV
-Sc
-Am
+ns
+Tc
 Tc
 Tc
 Yn
@@ -41746,7 +43324,7 @@ Fh
 Tc
 Tc
 jx
-HT
+js
 zV
 Sc
 MS
@@ -41991,18 +43569,18 @@ Pp
 Re
 yw
 as
-ml
-aK
+YC
+oG
 Tc
-ct
+uA
 OB
 UK
 DJ
-dy
+ku
 Vg
-hz
+Jj
 Tc
-iW
+zt
 Pe
 dg
 zf
@@ -42248,21 +43826,21 @@ Ku
 HG
 PM
 cz
-Em
-aP
-xS
+Sc
+qQ
+GK
 ov
 hP
 Rl
 nL
 hq
+My
 GG
-ij
-Qh
-je
-Em
+dk
+YZ
+MQ
 wu
-Qv
+Sc
 MS
 Va
 rO
@@ -42503,21 +44081,21 @@ HI
 SX
 vu
 HG
-ay
+MQ
 wu
-ae
-aX
+Sc
+vS
 Tc
-dk
+KD
 JM
-kx
-ku
-JU
+da
+Yv
+sF
 Vg
-ik
-ns
-jB
-gR
+sm
+tK
+Ev
+MQ
 wu
 Sc
 MS
@@ -42744,10 +44322,10 @@ cL
 cL
 cL
 lx
-HI
-HI
-HI
-HI
+Fe
+Fe
+Fe
+Fe
 Zf
 MF
 HI
@@ -42762,18 +44340,18 @@ vu
 HG
 IY
 wu
-Al
-Am
+Sc
+Tc
 Tc
 vj
 Sf
 XH
 qT
-gN
-YK
-ei
+pm
+xk
+dy
 Tc
-Am
+Tc
 IY
 xn
 Sc
@@ -43001,10 +44579,10 @@ cL
 cL
 cL
 lx
-qO
-qO
-qb
-HI
+Xx
+dh
+Rx
+Fe
 zK
 Bl
 HI
@@ -43022,16 +44600,16 @@ wu
 Sc
 Tc
 Tc
-KD
-Li
+BP
+JU
 NI
-fa
+lk
 JS
-oH
+II
 QX
 Tc
 Tc
-cX
+gI
 wu
 xR
 MS
@@ -43258,10 +44836,10 @@ cL
 cL
 cL
 lx
-qO
-qO
-qO
 YD
+wN
+pC
+KV
 rg
 ot
 na
@@ -43277,17 +44855,17 @@ HG
 rb
 wu
 YC
-Tc
+xV
 XS
-dC
-ek
-fd
-yp
-yp
-ha
-ir
+SZ
+LM
+kx
+vr
+tw
+zk
+Xq
 tY
-Tc
+MC
 rb
 wu
 YC
@@ -43515,10 +45093,10 @@ cL
 cL
 cL
 lx
-qO
-qO
-qO
-HI
+QH
+hc
+zR
+Fe
 HI
 HI
 HI
@@ -43534,17 +45112,17 @@ uG
 cX
 wu
 Sc
-MZ
-ck
+xV
+Ah
 Fn
 Hk
-eH
-ff
-ff
-By
-iG
-iP
-kb
+DI
+Yd
+pw
+up
+Gg
+nN
+MC
 MQ
 wu
 Sc
@@ -43772,10 +45350,10 @@ cL
 cL
 cL
 lx
-HI
+Fe
 Vv
-HI
-HI
+Fe
+Fe
 KS
 Dr
 DB
@@ -43790,9 +45368,9 @@ Xw
 uG
 MQ
 wu
-Sc
-MZ
-iB
+Al
+Tc
+Tc
 Lj
 IO
 rr
@@ -43800,8 +45378,8 @@ xU
 wY
 EZ
 NY
-kT
-zt
+Tc
+Tc
 MQ
 wu
 Sc
@@ -44029,10 +45607,10 @@ cL
 cL
 cL
 lx
-qO
-qO
-eG
-HI
+MW
+iW
+gP
+Fe
 Nt
 NK
 NK
@@ -44047,18 +45625,18 @@ FL
 uG
 Pg
 wu
-vs
+nC
+Up
 Tc
-ec
 zJ
-HF
+TF
 GN
-fp
+ir
 jf
-Op
+mj
 ft
-ke
 Tc
+TS
 ay
 Af
 Sc
@@ -44286,10 +45864,10 @@ cL
 cL
 cL
 lx
-qO
-qO
-qO
-HI
+wd
+iW
+Wb
+Fe
 rf
 NK
 Yj
@@ -44304,19 +45882,19 @@ DS
 ra
 MU
 wu
-Sc
-Tc
+Mc
+Ve
 Tc
 VV
-TO
-eP
-fF
-gW
-ff
+ng
+ve
+Rf
+Kq
+Yd
 nM
 Tc
-Tc
-MU
+TR
+Fw
 wu
 Sc
 cH
@@ -44543,13 +46121,13 @@ cL
 cL
 cL
 lx
-qO
-qO
-qO
-HI
+xO
+iW
+jO
+Fe
 PC
 NK
-XP
+Yj
 Yj
 NK
 YP
@@ -44559,23 +46137,23 @@ YB
 fl
 uG
 FZ
-Np
-sf
-cD
-Tc
+MQ
+AE
+Mc
+yx
 Tc
 Ui
 Tc
 yv
 yv
 yv
-hx
+yX
 FP
 Tc
-Tc
-cD
-sf
-cD
+or
+eN
+wu
+yG
 cH
 iH
 Gp
@@ -44800,10 +46378,10 @@ cL
 cL
 cL
 lx
-qO
-qO
-qO
-HI
+AZ
+gB
+aU
+Fe
 Tw
 NK
 Ce
@@ -44816,9 +46394,9 @@ uI
 aB
 OP
 uG
-rb
-wu
-YC
+xq
+sf
+cD
 Tc
 Tc
 Jn
@@ -44831,7 +46409,7 @@ wW
 Tc
 Tc
 MO
-wu
+Zq
 iJ
 cH
 ur
@@ -45057,12 +46635,12 @@ cL
 cL
 cL
 lx
-qO
-qO
-qO
-HI
+hg
+gM
+BC
+Fe
 AT
-NK
+ad
 Yj
 Yj
 NK
@@ -45314,10 +46892,10 @@ cL
 cL
 cL
 lx
-HI
-Vv
-HI
-HI
+Fe
+Su
+Fe
+Fe
 am
 NK
 Yj
@@ -45571,15 +47149,15 @@ cL
 cL
 cL
 lx
-HI
+Oj
 tb
 ts
-HI
+Oj
 AT
-NK
+wT
 SN
-NK
-NK
+lK
+lK
 op
 Wv
 Hh
@@ -45596,7 +47174,7 @@ Qc
 UE
 gY
 xr
-pw
+GP
 UE
 Qc
 AU
@@ -45828,10 +47406,10 @@ cL
 cL
 cL
 lx
-HI
-LL
+Oj
+ZG
 tT
-HI
+Oj
 KS
 ll
 KS
@@ -45851,11 +47429,11 @@ wz
 Wd
 bZ
 dv
+SH
 ht
-ht
-fe
-dv
-bZ
+at
+XF
+kv
 yh
 ZN
 MQ
@@ -46085,12 +47663,12 @@ cL
 cL
 cL
 lx
-HI
+cM
 pM
-LL
-jI
-LL
-LL
+rd
+CK
+Cz
+yy
 KS
 wF
 sN
@@ -46108,9 +47686,9 @@ SH
 px
 qk
 Oz
+rn
 SH
-dX
-at
+eA
 do
 Mp
 NP
@@ -46342,11 +47920,11 @@ cL
 cL
 cL
 lx
-HI
-HI
-HI
-HI
-LL
+Oj
+ok
+sJ
+Pq
+pv
 uN
 KS
 YV
@@ -46599,11 +48177,11 @@ cL
 cL
 cL
 lx
-lx
-lx
-HI
-HI
-LL
+Oj
+Oj
+ud
+IK
+eS
 ya
 KS
 tC
@@ -46856,11 +48434,11 @@ cL
 cL
 cL
 Cf
-cL
 lx
-HI
-ud
-LL
+qz
+AP
+sJ
+wv
 pz
 KS
 sD
@@ -46876,15 +48454,15 @@ my
 sL
 Gm
 SH
-Ti
+SH
 Ao
 kM
-FF
 SH
-iD
+SH
+at
 GT
 El
-ki
+at
 at
 od
 Dx
@@ -46896,7 +48474,7 @@ LN
 TM
 cp
 TH
-Tq
+Ks
 Ks
 Ra
 Fg
@@ -47113,12 +48691,12 @@ cL
 cL
 cL
 Zp
-cL
 lx
-HI
+Oj
 CW
-LL
-HI
+sJ
+wJ
+Oj
 KS
 KS
 KS
@@ -47152,9 +48730,9 @@ zH
 IX
 TM
 vf
+vY
+dr
 WJ
-WJ
-DQ
 dQ
 dQ
 dQ
@@ -47370,15 +48948,15 @@ cL
 cL
 cL
 Zp
-Cf
-lx
-HI
-qf
-PO
+ei
+Oj
+NJ
+sJ
+bq
 Oj
 lw
-sJ
-sJ
+Lc
+AB
 ox
 WD
 cW
@@ -47393,9 +48971,9 @@ SH
 SH
 Xl
 Ey
+li
 SH
-SH
-at
+Gc
 vK
 Uq
 at
@@ -47408,11 +48986,11 @@ Ay
 Lh
 IX
 TM
-ad
+bi
+BD
+BD
+MA
 WJ
-pU
-cL
-Cf
 cL
 cL
 Cf
@@ -47627,17 +49205,17 @@ cL
 cL
 cL
 Zp
-cL
 lx
-HI
-ok
+Oj
 PO
+sJ
+xs
 Oj
 bS
 Yr
 sJ
-mC
-fs
+ox
+WD
 cW
 aT
 td
@@ -47648,14 +49226,14 @@ vp
 eO
 HB
 Oj
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-lx
+Be
+rU
+SH
+SH
+at
+Lu
+NQ
+at
 Am
 PT
 ST
@@ -47666,10 +49244,10 @@ iF
 zn
 yP
 tZ
-WJ
+kd
 pU
-SP
-SP
+KW
+WJ
 SP
 gn
 SP
@@ -47884,16 +49462,16 @@ cL
 cL
 cL
 gn
-cL
 lx
-HI
-AP
-LL
+Oj
+PX
+sJ
+rC
 Oj
 ZK
 sJ
-sJ
-mC
+Yr
+ox
 Pa
 Xi
 qi
@@ -47906,11 +49484,11 @@ kQ
 Qk
 Oj
 mK
-we
 mK
 mK
+Xp
 mK
-we
+mK
 mK
 lx
 Am
@@ -47918,15 +49496,15 @@ Am
 sg
 Xb
 WJ
-DQ
-DQ
+WJ
 DQ
 WJ
 WJ
 WJ
-cL
-cL
-cL
+WJ
+WJ
+WJ
+WJ
 cL
 cL
 cL
@@ -48141,16 +49719,16 @@ cL
 cL
 cL
 gn
-cL
 lx
-HI
-cM
-LL
+Oj
+So
+sJ
+wv
 Oj
 xl
 sJ
-sJ
-mC
+nX
+Oj
 ka
 XK
 Dz
@@ -48163,11 +49741,11 @@ iU
 Oj
 Oj
 mK
+gg
 mK
 mK
 mK
-mK
-mK
+gg
 mK
 lx
 Am
@@ -48178,12 +49756,12 @@ qP
 Em
 Em
 Em
+Em
+Em
+Em
 TE
-VD
+tE
 TE
-cL
-cL
-cL
 cL
 cL
 cL
@@ -48398,17 +49976,17 @@ cL
 cL
 cL
 Zp
-Cf
-lx
-HI
-qz
-LL
+ei
 Oj
-bS
+On
 sJ
+kL
+Xd
+JC
+JC
 xB
-mC
-ka
+Cj
+Vx
 ry
 Kn
 km
@@ -48417,9 +49995,9 @@ Iy
 ME
 Iy
 xf
-Oj
+xf
+xf
 yg
-mK
 mK
 mK
 mK
@@ -48435,13 +50013,13 @@ ze
 Kd
 Ht
 dw
-uQ
 JN
-HN
+JN
+JN
 Er
-cL
-cL
-cL
+Yy
+hf
+wB
 cL
 cL
 cL
@@ -48655,36 +50233,36 @@ cL
 cL
 cL
 Zp
-cL
 lx
-HI
-PX
-PO
+Oj
+ch
+sJ
+sJ
 Oj
 Oj
 Oj
 Oj
-Fl
+Oj
 xu
-Fl
+Oj
 xf
 xf
 xf
 SE
 ji
 lJ
-xf
-lx
-mK
-mK
-Bp
-Bp
-mK
-Bp
-Bp
+Np
+Vp
+pb
 mK
 mK
 mK
+mK
+mK
+mK
+mK
+mK
+He
 lY
 IV
 Am
@@ -48693,11 +50271,11 @@ Am
 vd
 Am
 Am
+NO
 Am
 Am
-cL
-cL
-cL
+Am
+Am
 cL
 cL
 cL
@@ -48912,28 +50490,28 @@ cL
 cL
 cL
 Cf
-cL
 lx
-HI
-NJ
-LL
+Oj
+hn
+sJ
+sJ
 Oj
 FO
 en
-Oj
+ND
 Ma
-eS
-RK
-xf
+sJ
+Oj
+iS
 ps
 Na
 Tk
 hr
 Tz
+RK
+VD
 xf
-lx
-mK
-mK
+DE
 Bp
 Bp
 mK
@@ -48941,7 +50519,7 @@ Bp
 Bp
 mK
 mK
-mK
+Jt
 lY
 EM
 FU
@@ -48949,12 +50527,12 @@ Am
 Am
 Lo
 Am
-lx
-lx
+fi
+SV
+cP
+Am
+Am
 Cf
-cL
-cL
-cL
 cL
 cL
 cL
@@ -49168,37 +50746,37 @@ cL
 cL
 cL
 cL
-cL
-cL
+Cf
 lx
-HI
-HI
-LL
-Xx
+Oj
+GO
+sJ
+sJ
+Oj
 pH
-EC
+ND
 Oa
-Ct
+Ma
 dW
-yB
-xf
+Oj
+ki
 fv
 xf
 Ar
 LR
 eb
+RM
+VS
 xf
-lx
 mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
+Bp
+Bp
+si
+Bp
+Bp
+bv
+zm
+ug
 lY
 SU
 Am
@@ -49206,12 +50784,12 @@ Am
 Am
 bJ
 Am
-lx
-lx
+Am
+Am
+Am
+Am
+Am
 Cf
-SP
-gn
-SP
 SP
 SP
 SP
@@ -49425,38 +51003,38 @@ cL
 cL
 cL
 cL
-cL
-cL
+Cf
 lx
-lx
-HI
+Oj
+xa
+PQ
 VZ
 Oj
 jX
 ND
-JL
-oD
-Fy
-Dt
+ND
+Ma
+dX
+Oj
 xf
 sh
 xf
+vI
+yB
+Dt
+Ti
+Xf
+xf
+pb
 xf
 xf
 xf
 xf
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
+pb
+xf
+xf
+xf
+xf
 mK
 cL
 cL
@@ -49682,38 +51260,38 @@ cL
 cL
 cL
 cL
-cL
-cL
-cL
+Ns
 lx
-HI
-HI
+lx
+on
+Mm
+wP
 Oj
 qe
 nk
-JL
-Fy
+ND
+Ma
 Qi
 hI
 xf
-Ve
-ub
 xf
-lx
-lx
-lx
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
+xf
+xf
+xf
+EP
+Tq
+Zd
+Ef
+oz
+Jf
+gN
+Nd
+xG
+ZB
+RY
+MV
+xH
+pb
 mK
 cL
 cL
@@ -49939,12 +51517,12 @@ cL
 cL
 cL
 cL
-cL
-cL
-cL
+Ns
+Ns
 lx
-lx
-lx
+Oj
+Fl
+Fl
 Oj
 Oj
 Oj
@@ -49955,22 +51533,22 @@ Fl
 xf
 ag
 xf
+we
 xf
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
+FF
+Uh
+sZ
+Gd
+jL
+TC
+CY
+lv
+Bo
+Ru
+Gs
+gs
+MK
+pb
 mK
 cL
 cL
@@ -50197,11 +51775,11 @@ cL
 cL
 cL
 cL
-cL
-cL
-cL
-cL
-cL
+Ns
+Cf
+lx
+Ns
+Ns
 lx
 lx
 lx
@@ -50210,24 +51788,24 @@ le
 le
 le
 xf
+rv
+xf
+rv
+xf
+JP
 xf
 xf
-lx
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
+Ip
+xf
+xf
+xf
+Ms
+xf
+xf
+xf
+Nr
+xf
+xf
 mK
 cL
 cL
@@ -50466,25 +52044,25 @@ cL
 cL
 cL
 cL
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
+xf
+rT
+vs
+rT
+vs
+LU
+xf
+dT
+HU
+iQ
+xf
+Wa
+Fr
+Hq
+xf
+Pi
+jA
+Lr
+xf
 mK
 cL
 cL
@@ -50723,25 +52301,25 @@ cL
 cL
 cL
 cL
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
+xf
+tm
+xf
+tm
+xf
+tm
+xf
+aC
+cl
+bx
+xf
+Gt
+ld
+hi
+xf
+XE
+qm
+vh
+xf
 mK
 cL
 cL
@@ -50980,25 +52558,25 @@ cL
 cL
 cL
 cL
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
+xf
+ub
+xf
+ub
+xf
+ub
+xf
+vC
+Rk
+qL
+xf
+YS
+Mn
+qq
+xf
+AH
+ZS
+wm
+xf
 mK
 cL
 cL
@@ -51237,25 +52815,25 @@ cL
 cL
 cL
 cL
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
-mK
+xf
+xf
+xf
+xf
+xf
+xf
+xf
+xf
+rM
+xf
+xf
+xf
+rM
+xf
+xf
+xf
+rM
+xf
+xf
 mK
 cL
 cL
@@ -51501,17 +53079,17 @@ uf
 uf
 uf
 uf
+mb
+NS
+mb
 uf
+mb
+NS
+mb
 uf
-uf
-uf
-uf
-uf
-uf
-uf
-uf
-uf
-uf
+mb
+NS
+mb
 uf
 uf
 cL
@@ -52271,7 +53849,7 @@ cL
 cL
 cL
 cL
-Cw
+cL
 cL
 cL
 cL
@@ -52528,7 +54106,7 @@ cL
 cL
 cL
 cL
-cL
+Cw
 cL
 cL
 cL

--- a/_maps/map_files/Mining/nsv13/Rocinante.dmm
+++ b/_maps/map_files/Mining/nsv13/Rocinante.dmm
@@ -460,6 +460,15 @@
 /obj/structure/hull_plate,
 /turf/open/floor/plating/airless,
 /area/nostromo/hangar/starboard)
+"bI" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/tile/green{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/monotile/steel,
+/area/nostromo/medbay)
 "bJ" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4;
@@ -1739,14 +1748,26 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/engineering)
 "fk" = (
-/obj/effect/turf_decal/tile/green,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/techmaint,
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/tile/green{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "fl" = (
 /obj/structure/cable{
@@ -1973,16 +1994,20 @@
 /area/nostromo/engineering)
 "fH" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/green{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/item/paper{
 	info = "Place patient into stasis bed and attempt to apply first aid. Seek immediate professional medical help and ensure that the stasis unit remains active. Remain calm, do not attempt complex procedures by yourselves.";
 	name = "Dublanc Mining Corporation Medical  Procedures"
 	},
-/turf/open/floor/plasteel/techmaint,
+/obj/effect/turf_decal/tile/green{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "fI" = (
 /obj/structure/fluff/support_beam,
@@ -2129,52 +2154,66 @@
 /area/maintenance/nsv/mining_ship/central)
 "gb" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/tile/green{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/techmaint,
-/area/nostromo/medbay)
-"gc" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/o2,
 /obj/effect/turf_decal/tile/green{
-	dir = 8;
+	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel/techmaint,
-/area/nostromo/medbay)
-"gd" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/machinery/iv_drip,
-/obj/machinery/airalarm/directional/north{
-	req_access = null;
-	req_one_access_txt = "48"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/nostromo/medbay)
-"ge" = (
-/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4;
 	icon_state = "tile_corner"
 	},
+/obj/item/storage/box/hug/medical,
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/monotile/steel,
+/area/nostromo/medbay)
+"gc" = (
+/obj/item/storage/firstaid/o2,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/green{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/monotile/steel,
+/area/nostromo/medbay)
+"gd" = (
+/obj/machinery/airalarm/directional/north{
+	req_access = null;
+	req_one_access_txt = "48"
+	},
+/obj/machinery/sleeper,
+/obj/effect/turf_decal/tile/green{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/monotile/steel,
+/area/nostromo/medbay)
+"ge" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/techmaint,
-/area/nostromo/medbay)
-"gf" = (
-/turf/open/floor/monotile/light,
+/obj/effect/turf_decal/tile/green{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "gg" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -2182,9 +2221,6 @@
 	},
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/engineering/atmospherics)
-"gh" = (
-/turf/open/floor/monotile,
-/area/nostromo/medbay)
 "gi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2199,14 +2235,11 @@
 /area/nostromo/engineering)
 "gj" = (
 /obj/effect/turf_decal/tile/green{
-	dir = 8;
+	dir = 4;
 	icon_state = "tile_corner"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel/techmaint,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "gk" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
@@ -2240,26 +2273,21 @@
 /turf/open/floor/plasteel/ship/padded,
 /area/nostromo/medbay)
 "gm" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4;
-	icon_state = "tile_corner"
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/techmaint,
-/area/nostromo/medbay)
-"gn" = (
-/obj/machinery/stasis,
-/turf/open/floor/plasteel/grid/steel,
+/obj/effect/turf_decal/tile/green{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "go" = (
-/obj/machinery/computer/operating{
-	dir = 4;
-	icon_state = "computer"
-	},
-/turf/open/floor/monotile,
+/turf/open/floor/plasteel/techmaint,
 /area/nostromo/medbay)
 "gp" = (
 /obj/structure/hull_plate/end,
@@ -2436,12 +2464,15 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nostromo)
 "gN" = (
-/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
-	dir = 4;
+	dir = 8;
 	icon_state = "tile_corner"
 	},
-/turf/open/floor/plasteel/techmaint,
+/obj/effect/turf_decal/tile/green{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "gO" = (
 /obj/structure/chair/comfy/shuttle{
@@ -3143,11 +3174,17 @@
 /turf/open/floor/plating,
 /area/nostromo/engineering/atmospherics)
 "ij" = (
+/obj/machinery/stasis,
 /obj/effect/turf_decal/tile/green{
-	dir = 4;
+	dir = 8;
 	icon_state = "tile_corner"
 	},
-/turf/open/floor/plasteel/techmaint,
+/obj/effect/turf_decal/tile/green{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "ik" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -3826,34 +3863,40 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/nostromo/engineering)
 "jZ" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
-	dir = 4;
+	dir = 8;
 	icon_state = "tile_corner"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel/techmaint,
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "ka" = (
+/obj/machinery/light,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/tile/green{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/monotile/steel,
+/area/nostromo/medbay)
+"kb" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4;
 	icon_state = "tile_corner"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/techmaint,
-/area/nostromo/medbay)
-"kb" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel/techmaint,
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "kc" = (
 /obj/machinery/door/airlock/ship/hatch{
@@ -5611,20 +5654,17 @@
 /turf/closed/wall/ship,
 /area/nostromo/hangar/starboard)
 "UY" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
 /obj/machinery/camera{
 	c_tag = "Intensive Care Unit";
 	dir = 8;
 	network = list("mine")
 	},
-/turf/open/floor/plasteel/techmaint,
+/obj/effect/turf_decal/tile/green{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/monotile/steel,
 /area/nostromo/medbay)
 "VB" = (
 /obj/machinery/camera{
@@ -23056,9 +23096,9 @@ Wp
 rW
 fi
 fH
-gf
-gh
-gf
+go
+go
+go
 jZ
 dK
 fm
@@ -23313,9 +23353,9 @@ Cc
 ef
 fi
 gb
-gh
-gn
-gh
+go
+go
+go
 ka
 dK
 fo
@@ -23570,10 +23610,10 @@ db
 ee
 fi
 gc
-gf
 go
-gf
-jZ
+go
+go
+bI
 dK
 fw
 fC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Заливаем изменения Атласа и Ракинальта. `||Мне прям настолько лениво все это расписывать в 3 ночи, вы бы знали, все равно все, кому надо видели все в дискорде.||`
На Атласе:
- Появились свои дормы, которые закрывают прекрасный вид на ангар/муницииции нижней палубы.
- Инженерный отдел, чтобы он был чуть более _"безопасным"_ для сотрудником.
- У глав появились свои спальни. Ура?
- Сервис был перемапплен. Ура!
- Ремап мостика с Англ_НСВ успешно спи... по... перенесен!

На Ракинальте же появилась дополнительная аптечка и стазис кровать, слипер и пара мешков с кровью. Все равно эти чучела в зеленых противога--, ой, скафандрах, никогда не приходили обратно на основной корабль. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Маппинг из зер гуд.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add:На Атласе появились свои дормы.
add:Инженерный отдел, чтобы он был чуть более _"безопасным"_ для сотрудником.
add:У глав появились свои спальни. Ура?
add:Сервис был перемапплен. Ура.
add:Ремап мостика с Англ_НСВ успешно перенесен.
add:Медбей Ракинальта обновлен.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
